### PR TITLE
#36: Upgrade to Spark Commons 0.3.2 and use it

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,8 +33,8 @@ object Dependencies {
     List(
       "org.apache.spark" %% "spark-core" % sparkVersion % Provided,
       "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
-      "za.co.absa" %% s"spark-commons-spark$sparkVersionUpToMinor" % "0.3.1" % Provided,
-      "za.co.absa" %% "spark-commons-test" % "0.3.1" % Test,
+      "za.co.absa" %% s"spark-commons-spark$sparkVersionUpToMinor" % "0.3.2" % Provided,
+      "za.co.absa" %% "spark-commons-test" % "0.3.2" % Test,
       "com.typesafe" % "config" % "1.4.1",
       "com.github.mrpowers" %% "spark-fast-tests" % sparkFastTestsVersion(scalaVersion) % Test,
       "org.scalatest" %% "scalatest" % "3.2.2" % Test

--- a/src/main/scala/za/co/absa/standardization/ArrayTransformations.scala
+++ b/src/main/scala/za/co/absa/standardization/ArrayTransformations.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.types.{ArrayType, DataType, StructType}
 import org.apache.spark.sql.{Column, Dataset, Row, SparkSession}
 import org.slf4j.LoggerFactory
 import za.co.absa.spark.commons.implicits.StructTypeImplicits.StructTypeEnhancements
+import za.co.absa.spark.commons.utils.SchemaUtils
 
 object ArrayTransformations {
   private val logger = LoggerFactory.getLogger(this.getClass)
@@ -49,7 +50,7 @@ object ArrayTransformations {
   }
 
   def nestedWithColumn(ds: Dataset[Row])(columnName: String, column: Column): Dataset[Row] = {
-    val toks = columnName.split("\\.").toList
+    val toks = SchemaUtils.splitPath(columnName)
 
     def helper(tokens: List[String], pathAcc: Seq[String]): Column = {
       val currPath = (pathAcc :+ tokens.head).mkString(".")

--- a/src/main/scala/za/co/absa/standardization/validation/field/FieldValidator.scala
+++ b/src/main/scala/za/co/absa/standardization/validation/field/FieldValidator.scala
@@ -77,6 +77,6 @@ object FieldValidator extends FieldValidator {
     * @return simple type name
     */
   private[field] def simpleTypeName(typeName: String) = {
-    typeName.split("""\.""").last
+    typeName.split('.').last
   }
 }

--- a/src/test/scala/za/co/absa/standardization/interpreter/CounterPartySuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/CounterPartySuite.scala
@@ -19,8 +19,9 @@ package za.co.absa.standardization.interpreter
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
-import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, DefaultStandardizationConfig, StandardizationConfig}
+import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig}
 import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
 import za.co.absa.standardization.{ErrorMessage, LoggerTestBase, Standardization}
@@ -62,7 +63,7 @@ class CounterPartySuite extends AnyFunSuite with SparkTestBase with LoggerTestBa
       Root(Party(5, Seq(), null)),
       Root(Party(6, null, null))))
 
-    val std = Standardization.standardize(input, desiredSchema).cache()
+    val std = Standardization.standardize(input, desiredSchema).cacheIfNotCachedYet()
 
     logDataFrameContent(std)
 

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreterSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreterSuite.scala
@@ -21,7 +21,8 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.spark.commons.utils.JsonUtils
-import za.co.absa.spark.commons.test.{DefaultSparkConfiguration, SparkTestBase}
+import za.co.absa.spark.commons.test.SparkTestBase
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
 import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig, StandardizationConfig}
 import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
@@ -347,7 +348,7 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
 
     logDataFrameContent(src)
 
-    val std = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val actualSchema = std.schema.treeString

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_ArraySuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_ArraySuite.scala
@@ -26,11 +26,12 @@ import za.co.absa.spark.commons.utils.JsonUtils
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.DataFrameTestUtils.RowSeqToDf
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
-import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, DefaultStandardizationConfig, StandardizationConfig}
+import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig}
 import za.co.absa.standardization.schema.MetadataKeys
 import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
 import za.co.absa.standardization.{ErrorMessageFactory, LoggerTestBase, Standardization, ValidationException}
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_ArraySuite extends AnyFunSuite with SparkTestBase with LoggerTestBase with Matchers with DatasetComparer {
   import spark.implicits._
@@ -72,7 +73,7 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with SparkTestBa
       " |    |-- element: timestamp (containsNull = true)"
     )
 
-    val stdDF = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val stdDF = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     println(stdDF.schema.treeString)
     assert(stdDF.schema.treeString == expectedSchema) // checking schema first
 
@@ -108,7 +109,7 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with SparkTestBa
       " |    |-- element: timestamp (containsNull = true)"
     )
 
-    val stdDF = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val stdDF = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     assert(stdDF.schema.treeString == expectedSchema) // checking schema first
 
     val expectedData = Seq(
@@ -133,7 +134,7 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with SparkTestBa
     val src = seq.toDF(fieldName)
     val desiredSchema = generateDesiredSchema(TimestampType, s""""${MetadataKeys.Pattern}": "fubar"""")
     val caught = intercept[ValidationException] {
-      Standardization.standardize(src, desiredSchema, stdConfig).cache()
+      Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     }
 
     caught.getMessage should startWith ("A fatal schema validation error occurred.")
@@ -155,7 +156,7 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with SparkTestBa
         " |    |-- element: integer (containsNull = true)"
     )
 
-    val stdDF = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val stdDF = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     assert(stdDF.schema.treeString == expectedSchema) // checking schema first
 
     val expectedData = Seq(
@@ -220,7 +221,7 @@ class StandardizationInterpreter_ArraySuite extends AnyFunSuite with SparkTestBa
         " |    |    |-- element: string (containsNull = true)"
     )
 
-    val stdDF = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val stdDF = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     assert(stdDF.schema.treeString == expectedSchema) // checking schema first
 
     val expectedData = Seq(

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_BinarySuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_BinarySuite.scala
@@ -21,10 +21,11 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
-import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, DefaultStandardizationConfig, StandardizationConfig}
+import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig}
 import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
 import za.co.absa.standardization.{ErrorMessage, LoggerTestBase, Standardization, ValidationException}
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_BinarySuite extends AnyFunSuite with SparkTestBase with LoggerTestBase with Matchers {
 
@@ -56,7 +57,7 @@ class StandardizationInterpreter_BinarySuite extends AnyFunSuite with SparkTestB
     )
 
     val src = seq.toDF(fieldName)
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val result = std.as[BinaryRow].collect().toList
@@ -84,7 +85,7 @@ class StandardizationInterpreter_BinarySuite extends AnyFunSuite with SparkTestB
     )
 
     val src = seq.toDF(fieldName)
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val result = std.as[BinaryRow].collect().toList
@@ -102,7 +103,7 @@ class StandardizationInterpreter_BinarySuite extends AnyFunSuite with SparkTestB
 
     val src = seq.toDF(fieldName)
     val caught = intercept[ValidationException](
-      Standardization.standardize(src, desiredSchema).cache()
+      Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     )
 
     caught.errors.length shouldBe 1
@@ -128,7 +129,7 @@ class StandardizationInterpreter_BinarySuite extends AnyFunSuite with SparkTestB
       )
 
       val src = seq.toDF(fieldName)
-      val std = Standardization.standardize(src, desiredSchema).cache()
+      val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
       logDataFrameContent(std)
 
       val result = std.as[BinaryRow].collect().toList
@@ -158,7 +159,7 @@ class StandardizationInterpreter_BinarySuite extends AnyFunSuite with SparkTestB
     )
 
     val src = seq.toDF(fieldName)
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val result = std.as[BinaryRow].collect().toList
@@ -191,7 +192,7 @@ class StandardizationInterpreter_BinarySuite extends AnyFunSuite with SparkTestB
       )
 
       val src = seq.toDF(fieldName)
-      val std = Standardization.standardize(src, desiredSchema).cache()
+      val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
       logDataFrameContent(std)
 
       val result = std.as[BinaryRow].collect().toList

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
@@ -21,10 +21,11 @@ import org.apache.spark.sql.types.{DateType, MetadataBuilder, StructField, Struc
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
-import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig, StandardizationConfig}
+import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
 import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
 import za.co.absa.standardization.{ErrorMessage, LoggerTestBase, Standardization}
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
   import spark.implicits._
@@ -64,7 +65,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -90,7 +91,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -116,7 +117,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -142,7 +143,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -172,7 +173,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -203,7 +204,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
     val src = seq.toDF(fieldName)
     spark.sql("set spark.sql.legacy.timeParserPolicy=LEGACY")
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -233,7 +234,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -266,7 +267,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -300,7 +301,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)
@@ -332,7 +333,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DateRow].collect().toList)

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_DecimalSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_DecimalSuite.scala
@@ -22,11 +22,12 @@ import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
-import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig, StandardizationConfig}
+import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
 import za.co.absa.standardization.schema.MetadataKeys
 import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
 import za.co.absa.standardization.{ErrorMessage, LoggerTestBase, Standardization}
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_DecimalSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
   import spark.implicits._
@@ -81,7 +82,7 @@ class StandardizationInterpreter_DecimalSuite extends AnyFunSuite with SparkTest
     val src = seq.toDF("description","small", "big")
     logDataFrameContent(src)
 
-    val std = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = Seq(
@@ -142,7 +143,7 @@ class StandardizationInterpreter_DecimalSuite extends AnyFunSuite with SparkTest
         ErrorMessage.stdCastErr("big", "NaN")))
     )
 
-    val std = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[DecimalRow].collect().sortBy(_.description).toList)
@@ -179,7 +180,7 @@ class StandardizationInterpreter_DecimalSuite extends AnyFunSuite with SparkTest
         .build())
     ))
 
-    val std = Standardization.standardize(src, desiredSchemaWithAlters, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchemaWithAlters, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = List(
@@ -221,7 +222,7 @@ class StandardizationInterpreter_DecimalSuite extends AnyFunSuite with SparkTest
         .build())
     ))
 
-    val std = Standardization.standardize(src, desiredSchemaWithPatterns, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchemaWithPatterns, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = List(
@@ -273,7 +274,7 @@ class StandardizationInterpreter_DecimalSuite extends AnyFunSuite with SparkTest
         .build())
     ))
 
-    val std = Standardization.standardize(src, desiredSchemaWithPatterns, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchemaWithPatterns, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = List(

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
@@ -20,11 +20,12 @@ import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
-import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig, StandardizationConfig}
+import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
 import za.co.absa.standardization.schema.MetadataKeys
 import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
 import za.co.absa.standardization.{ErrorMessage, LoggerTestBase, Standardization}
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
   import spark.implicits._
@@ -77,7 +78,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
     val src = seq.toDF("description","floatField", "doubleField")
     logDataFrameContent(src)
 
-    val std = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = Seq(
@@ -121,7 +122,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
       FractionalRow("03-Long", Option(-value.toFloat), Option(value.toDouble))
     )
 
-    val std = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[FractionalRow].collect().sortBy(_.description).toList)
@@ -155,7 +156,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
         ErrorMessage.stdCastErr("doubleField", "NaN")))
     )
 
-    val std = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[FractionalRow].collect().sortBy(_.description).toList)
@@ -178,7 +179,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
     val src = seq.toDF("description","floatField", "doubleField")
     logDataFrameContent(src)
 
-    val std = Standardization.standardize(src, desiredSchemaWithInfinity, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchemaWithInfinity, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = Seq(
@@ -222,7 +223,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
         ErrorMessage.stdCastErr("doubleField", "NaN")))
     )
 
-    val std = Standardization.standardize(src, desiredSchemaWithInfinity, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchemaWithInfinity, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[FractionalRow].collect().sortBy(_.description).toList)
@@ -282,7 +283,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
         .build())
     ))
 
-    val std = Standardization.standardize(src, desiredSchemaWithAlters, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchemaWithAlters, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = List(
@@ -367,7 +368,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
         .build())
     ))
 
-    val std = Standardization.standardize(src, desiredSchemaWithPatterns, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchemaWithPatterns, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = List(

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_IntegralSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_IntegralSuite.scala
@@ -22,9 +22,10 @@ import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
-import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig, StandardizationConfig}
+import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
 import za.co.absa.standardization.schema.MetadataKeys
 import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.standardization.udf.UDFLibrary
 import za.co.absa.standardization.{ErrorMessage, LoggerTestBase, Standardization}
 
@@ -72,7 +73,7 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
       .csv(s"${pathToTestData}integral_overflow_test.csv")
     logDataFrameContent(src)
 
-    val std = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = Seq(
@@ -112,7 +113,7 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
     val src = spark.read.json(s"${pathToTestData}integral_overflow_test_text.json")
     logDataFrameContent(src)
 
-    val std = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = Seq(
@@ -152,7 +153,7 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
     val src = spark.read.json(s"${pathToTestData}integral_overflow_test_numbers.json")
     logDataFrameContent(src)
 
-    val std = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = Seq(
@@ -193,7 +194,7 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
     ))
     logDataFrameContent(src)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = Seq(
@@ -247,7 +248,7 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
     val src = spark.createDataFrame(seq)
     logDataFrameContent(src)
 
-    val std = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = Seq(
@@ -334,7 +335,7 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
     val src = spark.createDataFrame(seq)
     logDataFrameContent(src)
 
-    val std = Standardization.standardize(src, desiredSchema, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = Seq(
@@ -415,7 +416,7 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
         .build())
     ))
 
-    val std = Standardization.standardize(src, desiredSchemaWithAlters, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchemaWithAlters, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = List(
@@ -479,7 +480,7 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
         .build())
     ))
 
-    val std = Standardization.standardize(src, desiredSchemaWithPatterns, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchemaWithPatterns, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = List(
@@ -540,7 +541,7 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
         .build())
     ))
 
-    val std = Standardization.standardize(src, desiredSchemaWithAlters, stdConfig).cache()
+    val std = Standardization.standardize(src, desiredSchemaWithAlters, stdConfig).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     val exp = List(

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
@@ -17,15 +17,15 @@
 package za.co.absa.standardization.interpreter
 
 import java.sql.Timestamp
-import org.apache.spark.SPARK_VERSION
 import org.apache.spark.sql.types.{MetadataBuilder, StructField, StructType, TimestampType}
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
-import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig, StandardizationConfig}
+import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
 import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
 import za.co.absa.standardization.{ErrorMessage, LoggerTestBase, Standardization}
+import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
   import spark.implicits._
@@ -63,7 +63,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -93,7 +93,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -119,7 +119,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -145,7 +145,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -175,7 +175,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -210,7 +210,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -240,7 +240,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -274,7 +274,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -305,7 +305,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -336,7 +336,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     assertResult(exp)(std.as[TimestampRow].collect().toList)
@@ -368,7 +368,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
 
     val src = seq.toDF(fieldName)
 
-    val std = Standardization.standardize(src, desiredSchema).cache()
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
     logDataFrameContent(std)
 
     std.show(false)


### PR DESCRIPTION
* using Spark Commons 0.3.2
* use method `cacheIfNotCachedYet` instead of `cache`
* use `splitPath` method

Closes #36 