### PR TITLE
Move error message into spark commons :45

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -33,7 +33,7 @@ object Dependencies {
     List(
       "org.apache.spark" %% "spark-core" % sparkVersion % Provided,
       "org.apache.spark" %% "spark-sql" % sparkVersion % Provided,
-      "za.co.absa" %% s"spark-commons-spark$sparkVersionUpToMinor" % "0.4.0" % Provided,
+      "za.co.absa" %% s"spark-commons-spark$sparkVersionUpToMinor" % "0.5.0" % Provided,
       "za.co.absa" %% "spark-commons-test" % "0.4.0" % Test,
       "com.typesafe" % "config" % "1.4.1",
       "com.github.mrpowers" %% "spark-fast-tests" % sparkFastTestsVersion(scalaVersion) % Test,

--- a/src/main/scala/za/co/absa/standardization/SchemaValidator.scala
+++ b/src/main/scala/za/co/absa/standardization/SchemaValidator.scala
@@ -35,7 +35,7 @@ object SchemaValidator {
     * @return A list of ValidationErrors objects, each containing a column name and the list of errors and warnings
     */
   def validateSchema(schema: StructType)(implicit defaults: TypeDefaults): List[FieldValidationIssue] = {
-    var errorsAccumulator = new ListBuffer[FieldValidationIssue]
+    val errorsAccumulator = new ListBuffer[FieldValidationIssue]//
     val flatSchema = flattenSchema(schema)
     for {s <- flatSchema} {
       val fieldWithPath = if (s.structPath.isEmpty) s.field else s.field.copy(name = s.structPath + "." + s.field.name)
@@ -105,7 +105,7 @@ object SchemaValidator {
   private def flattenSchema(schema: StructType): Seq[FlatField] = {
 
     def flattenStruct(schema: StructType, structPath: String): Seq[FlatField] = {
-      var fields = new ListBuffer[FlatField]
+      val fields = new ListBuffer[FlatField]
       val prefix = if (structPath.isEmpty) structPath else structPath + "."
       for (field <- schema) {
         field.dataType match {
@@ -120,7 +120,7 @@ object SchemaValidator {
     }
 
     def flattenArray(field: StructField, arr: ArrayType, structPath: String): Seq[FlatField] = {
-      var arrayFields = new ListBuffer[FlatField]
+      val arrayFields = new ListBuffer[FlatField]
       arr.elementType match {
         case stuctInArray: StructType => arrayFields ++= flattenStruct(stuctInArray, structPath)
         case arrayType: ArrayType => arrayFields ++= flattenArray(field, arrayType, structPath + "[]")

--- a/src/main/scala/za/co/absa/standardization/SchemaValidator.scala
+++ b/src/main/scala/za/co/absa/standardization/SchemaValidator.scala
@@ -18,6 +18,7 @@ package za.co.absa.standardization
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
+import za.co.absa.spark.commons.errorhandling.ErrorMessage
 import za.co.absa.standardization.types.{TypeDefaults, TypedStructField}
 import za.co.absa.standardization.validation.field.FieldValidationIssue
 

--- a/src/main/scala/za/co/absa/standardization/Standardization.scala
+++ b/src/main/scala/za/co/absa/standardization/Standardization.scala
@@ -25,7 +25,7 @@ import za.co.absa.spark.commons.errorhandling.ErrorMessage
 import za.co.absa.spark.commons.implicits.StructTypeImplicits.StructTypeEnhancements
 import za.co.absa.standardization.config.{DefaultStandardizationConfig, StandardizationConfig}
 import za.co.absa.standardization.stages.{SchemaChecker, TypeParser}
-import za.co.absa.standardization.types.{CommonTypeDefaults, ParseOutput, TypeDefaults}
+import za.co.absa.standardization.types.{ParseOutput, TypeDefaults}
 import za.co.absa.standardization.udf.{UDFLibrary, UDFNames}
 
 object Standardization {

--- a/src/main/scala/za/co/absa/standardization/Standardization.scala
+++ b/src/main/scala/za/co/absa/standardization/Standardization.scala
@@ -21,7 +21,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 import org.slf4j.{Logger, LoggerFactory}
-
+import za.co.absa.spark.commons.errorhandling.ErrorMessage
 import za.co.absa.spark.commons.implicits.StructTypeImplicits.StructTypeEnhancements
 import za.co.absa.standardization.config.{DefaultStandardizationConfig, StandardizationConfig}
 import za.co.absa.standardization.stages.{SchemaChecker, TypeParser}

--- a/src/main/scala/za/co/absa/standardization/StandardizationErrorMessage.scala
+++ b/src/main/scala/za/co/absa/standardization/StandardizationErrorMessage.scala
@@ -18,7 +18,9 @@ package za.co.absa.standardization
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types.StructType
+import za.co.absa.spark.commons.errorhandling.ErrorMessage
 import za.co.absa.standardization.config.{ErrorCodesConfig, StandardizationConfig}
+//import za.co.absa.spark.commons.errorhandling.ErrorMessage._
 
 /**
  * Case class to represent an error message
@@ -30,42 +32,36 @@ import za.co.absa.standardization.config.{ErrorCodesConfig, StandardizationConfi
  * @param rawValues - Sequence of raw values (which are the potential culprits of the error)
  * @param mappings - Sequence of Mappings i.e Mapping Table Column -> Equivalent Mapped Dataset column
  */
-case class ErrorMessage(errType: String, errCode: String, errMsg: String, errCol: String, rawValues: Seq[String], mappings: Seq[Mapping] = Seq())
+//case class ErrorMessage(errType: String, errCode: String, errMsg: String, errCol: String, rawValues: Seq[String], mappings: Seq[Mapping] = Seq())
 //TODO mapping to be discussed
-case class Mapping(mappingTableColumn: String, mappedDatasetColumn: String)
+//case class Mapping(mappingTableColumn: String, mappedDatasetColumn: String)
 
-object ErrorMessage {
-  val errorColumnName = "errCol"
+object StandardizationErrorMessage {
+//  val errorColumnName = "errCol"
 
   def stdCastErr(errCol: String, rawValue: String)(implicit errorCodes: ErrorCodesConfig): ErrorMessage = ErrorMessage(
-    errType = "stdCastError",
-    errCode = errorCodes.castError,
-    errMsg = "Standardization Error - Type cast",
-    errCol = errCol,
-    rawValues = Seq(rawValue))
+    "stdCastError",
+    errorCodes.castError,
+    "Standardization Error - Type cast",
+    errCol,
+    Seq(rawValue))
   def stdNullErr(errCol: String)(implicit errorCodes: ErrorCodesConfig): ErrorMessage = ErrorMessage(
-    errType = "stdNullError",
-    errCode = errorCodes.nullError,
-    errMsg = "Standardization Error - Null detected in non-nullable attribute",
-    errCol = errCol,
-    rawValues = Seq("null"))
+    "stdNullError",
+    errorCodes.nullError,
+    "Standardization Error - Null detected in non-nullable attribute",
+    errCol,
+    Seq("null"))
   def stdTypeError(errCol: String, sourceType: String, targetType: String)
                   (implicit errorCodes: ErrorCodesConfig): ErrorMessage = ErrorMessage(
-    errType = "stdTypeError",
-    errCode = errorCodes.typeError,
-    errMsg = s"Standardization Error - Type '$sourceType' cannot be cast to '$targetType'",
-    errCol = errCol,
-    rawValues = Seq.empty)
+    "stdTypeError",
+    errorCodes.typeError,
+    s"Standardization Error - Type '$sourceType' cannot be cast to '$targetType'",
+    errCol,
+    Seq.empty)
   def stdSchemaError(errRow: String)(implicit errorCodes: ErrorCodesConfig): ErrorMessage = ErrorMessage(
-    errType = "stdSchemaError",
-    errCode = errorCodes.schemaError,
-    errMsg = s"The input data does not adhere to requested schema",
-    errCol = null, // scalastyle:ignore null
-    rawValues = Seq(errRow))
-
-  def errorColSchema(implicit spark: SparkSession): StructType = {
-    import spark.implicits._
-    spark.emptyDataset[ErrorMessage].schema
-  }
+    "stdSchemaError",
+    errorCodes.schemaError,
+    s"The input data does not adhere to requested schema",
+    null, // scalastyle:ignore null
+    Seq(errRow))
 }
-

--- a/src/main/scala/za/co/absa/standardization/StandardizationErrorMessage.scala
+++ b/src/main/scala/za/co/absa/standardization/StandardizationErrorMessage.scala
@@ -16,11 +16,8 @@
 
 package za.co.absa.standardization
 
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.types.StructType
 import za.co.absa.spark.commons.errorhandling.ErrorMessage
-import za.co.absa.standardization.config.{ErrorCodesConfig, StandardizationConfig}
-//import za.co.absa.spark.commons.errorhandling.ErrorMessage._
+import za.co.absa.standardization.config.{ErrorCodesConfig}
 
 /**
  * Case class to represent an error message
@@ -32,12 +29,8 @@ import za.co.absa.standardization.config.{ErrorCodesConfig, StandardizationConfi
  * @param rawValues - Sequence of raw values (which are the potential culprits of the error)
  * @param mappings - Sequence of Mappings i.e Mapping Table Column -> Equivalent Mapped Dataset column
  */
-//case class ErrorMessage(errType: String, errCode: String, errMsg: String, errCol: String, rawValues: Seq[String], mappings: Seq[Mapping] = Seq())
-//TODO mapping to be discussed
-//case class Mapping(mappingTableColumn: String, mappedDatasetColumn: String)
 
 object StandardizationErrorMessage {
-//  val errorColumnName = "errCol"
 
   def stdCastErr(errCol: String, rawValue: String)(implicit errorCodes: ErrorCodesConfig): ErrorMessage = ErrorMessage(
     "stdCastError",

--- a/src/main/scala/za/co/absa/standardization/StandardizationErrorMessage.scala
+++ b/src/main/scala/za/co/absa/standardization/StandardizationErrorMessage.scala
@@ -19,17 +19,6 @@ package za.co.absa.standardization
 import za.co.absa.spark.commons.errorhandling.ErrorMessage
 import za.co.absa.standardization.config.{ErrorCodesConfig}
 
-/**
- * Case class to represent an error message
- *
- * @param errType - Type or source of the error
- * @param errCode - Internal error code
- * @param errMsg - Textual description of the error
- * @param errCol - The name of the column where the error occurred
- * @param rawValues - Sequence of raw values (which are the potential culprits of the error)
- * @param mappings - Sequence of Mappings i.e Mapping Table Column -> Equivalent Mapped Dataset column
- */
-
 object StandardizationErrorMessage {
 
   def stdCastErr(errCol: String, rawValue: String)(implicit errorCodes: ErrorCodesConfig): ErrorMessage = ErrorMessage(

--- a/src/main/scala/za/co/absa/standardization/udf/UDFLibrary.scala
+++ b/src/main/scala/za/co/absa/standardization/udf/UDFLibrary.scala
@@ -22,8 +22,9 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Row, SparkSession}
 import za.co.absa.standardization.config.{ErrorCodesConfig, StandardizationConfig}
 import za.co.absa.standardization.udf.UDFNames._
-import za.co.absa.standardization.ErrorMessage
 import za.co.absa.spark.commons.OncePerSparkSession
+import za.co.absa.spark.commons.errorhandling.ErrorMessage
+import za.co.absa.standardization.StandardizationErrorMessage
 
 import scala.collection.mutable
 import scala.util.{Failure, Success, Try}
@@ -35,12 +36,12 @@ class UDFLibrary(stdConfig: StandardizationConfig)(implicit spark: SparkSession)
   override protected def register(implicit spark: SparkSession): Unit = {
 
     spark.udf.register(stdCastErr, { (errCol: String, rawValue: String) =>
-      ErrorMessage.stdCastErr(errCol, rawValue)
+      StandardizationErrorMessage.stdCastErr(errCol, rawValue)
     })
 
-    spark.udf.register(stdNullErr, { errCol: String => ErrorMessage.stdNullErr(errCol) })
+    spark.udf.register(stdNullErr, { errCol: String => StandardizationErrorMessage.stdNullErr(errCol) })
 
-    spark.udf.register(stdSchemaErr, { errRow: String => ErrorMessage.stdSchemaError(errRow) })
+    spark.udf.register(stdSchemaErr, { errRow: String => StandardizationErrorMessage.stdSchemaError(errRow) })
 
     spark.udf.register(arrayDistinctErrors, // this UDF is registered for _spark-hats_ library sake
       (arr: mutable.WrappedArray[ErrorMessage]) =>

--- a/src/main/scala/za/co/absa/standardization/udf/UDFResult.scala
+++ b/src/main/scala/za/co/absa/standardization/udf/UDFResult.scala
@@ -16,7 +16,8 @@
 
 package za.co.absa.standardization.udf
 
-import za.co.absa.standardization.ErrorMessage
+import za.co.absa.spark.commons.errorhandling.ErrorMessage
+import za.co.absa.standardization.StandardizationErrorMessage
 import za.co.absa.standardization.config.StandardizationConfig
 
 import scala.util.{Failure, Success, Try}
@@ -32,8 +33,8 @@ object UDFResult {
   def fromTry[T](result: Try[Option[T]], columnName: String, rawValue: String, stdConfig: StandardizationConfig, defaultValue: Option[T] = None): UDFResult[T] = {
     result match {
       case Success(success)                       => UDFResult.success(success)
-      case Failure(_) if Option(rawValue).isEmpty => UDFResult(defaultValue, Seq(ErrorMessage.stdNullErr(columnName)(stdConfig.errorCodes)))
-      case Failure(_)                             => UDFResult(defaultValue, Seq(ErrorMessage.stdCastErr(columnName, rawValue)(stdConfig.errorCodes)))
+      case Failure(_) if Option(rawValue).isEmpty => UDFResult(defaultValue, Seq(StandardizationErrorMessage.stdNullErr(columnName)(stdConfig.errorCodes)))
+      case Failure(_)                             => UDFResult(defaultValue, Seq(StandardizationErrorMessage.stdCastErr(columnName, rawValue)(stdConfig.errorCodes)))
     }
   }
 }

--- a/src/test/scala/za/co/absa/standardization/StandardizationCsvSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/StandardizationCsvSuite.scala
@@ -42,14 +42,12 @@ class StandardizationCsvSuite extends AnyFunSuite with SparkTestBase {
   private implicit val udfLib: UDFLibrary = new UDFLibrary(stdConfig)
   private implicit val defaults: TypeDefaults = CommonTypeDefaults
 
-
-  private val csvContent = spark.sparkContext.parallelize(
-    """101,102,1,2019-05-04,2019-05-04
-      |201,202,2,2019-05-05,2019-05-05
-      |301,302,1,2019-05-06,2019-05-06
-      |401,402,1,2019-05-07,2019-05-07
-      |501,502,,2019-05-08,2019-05-08"""
-      .stripMargin.lines.toList ).toDS()
+  private val csvContent = spark.sparkContext.parallelize(List(
+    """101,102,1,2019-05-04,2019-05-04""",
+    """201,202,2,2019-05-05,2019-05-05""",
+    """301,302,1,2019-05-06,2019-05-06""",
+    """401,402,1,2019-05-07,2019-05-07""",
+    """501,502,,2019-05-08,2019-05-08""")).toDS()
 
   test("Test standardizing a CSV without special columns") {
     val schema: StructType = StructType(Seq(

--- a/src/test/scala/za/co/absa/standardization/StandardizationCsvSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/StandardizationCsvSuite.scala
@@ -19,11 +19,12 @@ package za.co.absa.standardization
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.spark.commons.errorhandling.ErrorMessage
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
 import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig}
-import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
+import za.co.absa.standardization.types.{CommonTypeDefaults, TypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
 
 

--- a/src/test/scala/za/co/absa/standardization/StandardizationCsvSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/StandardizationCsvSuite.scala
@@ -38,7 +38,7 @@ class StandardizationCsvSuite extends AnyFunSuite with SparkTestBase {
       .copy(recordIdStrategy = NoId
       )
     )
-//  private val stdConfig = defaultStdConfig.copy(metadataColumns = defaultStdConfig.metadataColumns.copy(recordIdStrategy = NoId))
+
   private implicit val udfLib: UDFLibrary = new UDFLibrary(stdConfig)
   private implicit val defaults: TypeDefaults = CommonTypeDefaults
 

--- a/src/test/scala/za/co/absa/standardization/TestSamples.scala
+++ b/src/test/scala/za/co/absa/standardization/TestSamples.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.standardization
 
+import za.co.absa.spark.commons.errorhandling.ErrorMessage
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
 import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig, StandardizationConfig}
 
@@ -83,10 +84,10 @@ object TestSamples {
 
   val resData = List(
      StdEmployee(name = "John0", surname = "Unknown Surname", hoursWorked = Some(List(8, 7, 8, 9, 12, 0)),
-        employeeNumbers = List(EmployeeNumberStd("SAP", List(456, 123)), EmployeeNumberStd("WD", List(5))), startDate =  new java.sql.Date(startDate), errCol = List(ErrorMessage.stdNullErr("surname"), ErrorMessage.stdNullErr("hoursWorked[*]"))),
-     StdEmployee(name = "John1", surname = "Doe1", hoursWorked = Some(List(99, 99, 76, 12, 12, 24)), startDate = new java.sql.Date(0), errCol = List(ErrorMessage.stdCastErr("startDate", "Two Thousand Something"))),
-     StdEmployee(name = "John2", surname = "Unknown Surname", hoursWorked = None, startDate = new java.sql.Date(startDate), updated = Some(Timestamp.valueOf("2015-07-16 13:32:24")), errCol = List(ErrorMessage.stdNullErr("surname"), ErrorMessage.stdNullErr("hoursWorked"))),
-     StdEmployee(name = "John3", surname = "Unknown Surname", hoursWorked = Some(List()), startDate = new java.sql.Date(startDate), updated = Some(Timestamp.valueOf("2015-07-16 10:32:24")), errCol = List(ErrorMessage.stdNullErr("surname"))))
+        employeeNumbers = List(EmployeeNumberStd("SAP", List(456, 123)), EmployeeNumberStd("WD", List(5))), startDate =  new java.sql.Date(startDate), errCol = List(StandardizationErrorMessage.stdNullErr("surname"), StandardizationErrorMessage.stdNullErr("hoursWorked[*]"))),
+     StdEmployee(name = "John1", surname = "Doe1", hoursWorked = Some(List(99, 99, 76, 12, 12, 24)), startDate = new java.sql.Date(0), errCol = List(StandardizationErrorMessage.stdCastErr("startDate", "Two Thousand Something"))),
+     StdEmployee(name = "John2", surname = "Unknown Surname", hoursWorked = None, startDate = new java.sql.Date(startDate), updated = Some(Timestamp.valueOf("2015-07-16 13:32:24")), errCol = List(StandardizationErrorMessage.stdNullErr("surname"), StandardizationErrorMessage.stdNullErr("hoursWorked"))),
+     StdEmployee(name = "John3", surname = "Unknown Surname", hoursWorked = Some(List()), startDate = new java.sql.Date(startDate), updated = Some(Timestamp.valueOf("2015-07-16 10:32:24")), errCol = List(StandardizationErrorMessage.stdNullErr("surname"))))
 
   val dateSamples = List(DateTimestampData(
     1,

--- a/src/test/scala/za/co/absa/standardization/TestSamples.scala
+++ b/src/test/scala/za/co/absa/standardization/TestSamples.scala
@@ -18,7 +18,7 @@ package za.co.absa.standardization
 
 import za.co.absa.spark.commons.errorhandling.ErrorMessage
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
-import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig, StandardizationConfig}
+import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
 
 import java.math.BigDecimal
 import java.sql.{Date, Timestamp}

--- a/src/test/scala/za/co/absa/standardization/interpreter/CounterPartySuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/CounterPartySuite.scala
@@ -18,13 +18,14 @@ package za.co.absa.standardization.interpreter
 
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.spark.commons.errorhandling.ErrorMessage
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
 import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig}
-import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
+import za.co.absa.standardization.types.{CommonTypeDefaults, TypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
-import za.co.absa.standardization.{ErrorMessage, LoggerTestBase, Standardization}
+import za.co.absa.standardization.{LoggerTestBase, Standardization}
 
 case class Root(ConformedParty: Party, errCol: Seq[ErrorMessage] = Seq.empty)
 case class Party(key: Integer, clientKeys1: Seq[String], clientKeys2: Seq[String])

--- a/src/test/scala/za/co/absa/standardization/interpreter/DateTimeSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/DateTimeSuite.scala
@@ -20,10 +20,11 @@ import java.sql.{Date, Timestamp}
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
 import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.spark.commons.errorhandling.ErrorMessage
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
 import za.co.absa.standardization.stages.SchemaChecker
-import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
+import za.co.absa.standardization.types.{CommonTypeDefaults, TypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
 import za.co.absa.standardization.validation.field.FieldValidationIssue
 import za.co.absa.standardization._
@@ -104,12 +105,12 @@ class DateTimeSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
       null,
       ts, ts, ts, null, ts0, ts0,
       List(
-        ErrorMessage.stdCastErr("dateSampleWrong1","10-20-2017"),
-        ErrorMessage.stdCastErr("dateSampleWrong2","201711"),
-        ErrorMessage.stdCastErr("dateSampleWrong3",""),
-        ErrorMessage.stdCastErr("timestampSampleWrong1", "20171020T081131"),
-        ErrorMessage.stdCastErr("timestampSampleWrong2", "2017-10-20t081131"),
-        ErrorMessage.stdCastErr("timestampSampleWrong3", "2017-10-20")
+        StandardizationErrorMessage.stdCastErr("dateSampleWrong1","10-20-2017"),
+        StandardizationErrorMessage.stdCastErr("dateSampleWrong2","201711"),
+        StandardizationErrorMessage.stdCastErr("dateSampleWrong3",""),
+        StandardizationErrorMessage.stdCastErr("timestampSampleWrong1", "20171020T081131"),
+        StandardizationErrorMessage.stdCastErr("timestampSampleWrong2", "2017-10-20t081131"),
+        StandardizationErrorMessage.stdCastErr("timestampSampleWrong3", "2017-10-20")
       )
     ))
     val std: Dataset[Row] = Standardization.standardize(data, schemaOk, stdConfig)

--- a/src/test/scala/za/co/absa/standardization/interpreter/DateTimeSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/DateTimeSuite.scala
@@ -28,7 +28,7 @@ import za.co.absa.standardization.types.{CommonTypeDefaults, TypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
 import za.co.absa.standardization.validation.field.FieldValidationIssue
 import za.co.absa.standardization._
-import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, DefaultStandardizationConfig, ErrorCodesConfig, StandardizationConfig}
+import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
 
 
 class DateTimeSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreterSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreterSuite.scala
@@ -25,7 +25,7 @@ import za.co.absa.spark.commons.utils.JsonUtils
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
-import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig, StandardizationConfig}
+import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
 import za.co.absa.standardization.types.{CommonTypeDefaults, TypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
 import za.co.absa.standardization.{FileReader, LoggerTestBase, Standardization, StandardizationErrorMessage}

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreterSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreterSuite.scala
@@ -20,14 +20,15 @@ import java.sql.{Date, Timestamp}
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.spark.commons.errorhandling.ErrorMessage
 import za.co.absa.spark.commons.utils.JsonUtils
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
 import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig, StandardizationConfig}
-import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
+import za.co.absa.standardization.types.{CommonTypeDefaults, TypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
-import za.co.absa.standardization.{ErrorMessage, FileReader, LoggerTestBase, Standardization}
+import za.co.absa.standardization.{FileReader, LoggerTestBase, Standardization, StandardizationErrorMessage}
 
 import java.util.TimeZone
 
@@ -125,7 +126,7 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
       MyWrapper(MyHolder("447129"))))
 
     val exp = Seq(
-      MyWrapperStd(MyHolder(""), Seq(ErrorMessage.stdNullErr("counterparty.yourRef"))),
+      MyWrapperStd(MyHolder(""), Seq(StandardizationErrorMessage.stdNullErr("counterparty.yourRef"))),
       MyWrapperStd(MyHolder("447129"), Seq()))
 
     val schema = StructType(Seq(
@@ -149,7 +150,7 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
       ErrorPreserveStd("a", 1, List()),
       ErrorPreserveStd("b", 2, List()),
       ErrorPreserveStd("c", 3, List(new ErrorMessage("myErrorType", "E-1", "Testing This stuff", "whatEvColumn", Seq("some value")))),
-      ErrorPreserveStd("d", 0, List(ErrorMessage.stdCastErr("b", "abc"),
+      ErrorPreserveStd("d", 0, List(StandardizationErrorMessage.stdCastErr("b", "abc"),
         new ErrorMessage("myErrorType2", "E-2", "Testing This stuff blabla", "whatEvColumn2", Seq("some other value")))))
 
     val expSchema = spark.emptyDataset[ErrorPreserveStd].schema
@@ -239,7 +240,7 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
 
     val expected = List (
       StdTime(1, new Date(1507075200000L), new Timestamp(1507115471000L), List()),
-      StdTime(2, new Date(1735689600000L), new Timestamp(1735741586000L), List(ErrorMessage.stdCastErr("date", ""), ErrorMessage.stdCastErr("timestamp", "")))
+      StdTime(2, new Date(1735689600000L), new Timestamp(1735741586000L), List(StandardizationErrorMessage.stdCastErr("date", ""), StandardizationErrorMessage.stdCastErr("timestamp", "")))
     )
 
     val standardizedDF = Standardization.standardize(sourceDF, schema, stdConfig)
@@ -263,7 +264,7 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
 
     val expected = List (
       StdTime(1, new Date(1507075200000L), new Timestamp(1507115471000L), List()),
-      StdTime(2, new Date(1735689600000L), new Timestamp(1735741586000L), List(ErrorMessage.stdCastErr("date", ""), ErrorMessage.stdCastErr("timestamp", "")))
+      StdTime(2, new Date(1735689600000L), new Timestamp(1735741586000L), List(StandardizationErrorMessage.stdCastErr("date", ""), StandardizationErrorMessage.stdCastErr("timestamp", "")))
     )
 
     val standardizedDF = Standardization.standardize(sourceDF, schema, stdConfig)
@@ -287,7 +288,7 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
 
     val expected = List (
       StdTime(1, new Date(1507075200000L), new Timestamp(1507115471000L), List()),
-      StdTime(2, null, new Timestamp(0L), List(ErrorMessage.stdCastErr("date", ""), ErrorMessage.stdCastErr("timestamp", "")))
+      StdTime(2, null, new Timestamp(0L), List(StandardizationErrorMessage.stdCastErr("date", ""), StandardizationErrorMessage.stdCastErr("timestamp", "")))
     )
 
     val standardizedDF = Standardization.standardize(sourceDF, schema, stdConfig)
@@ -311,7 +312,7 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
 
     val expected = List (
       StdTime(1, new Date(1507075200000L), new Timestamp(1507115471000L), List()),
-      StdTime(2, new Date(0L), null, List(ErrorMessage.stdCastErr("date", ""), ErrorMessage.stdCastErr("timestamp", "")))
+      StdTime(2, new Date(0L), null, List(StandardizationErrorMessage.stdCastErr("date", ""), StandardizationErrorMessage.stdCastErr("timestamp", "")))
     )
 
     val standardizedDF = Standardization.standardize(sourceDF, schema, stdConfig)
@@ -380,11 +381,11 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
     val exp = Seq(
       PatientRow("Jane", "Goodall", BodyStats(164, 61, "green", Option(true), Seq(36.6, 36.7, 37.0, 36.6))),
       PatientRow("Scott", "Lang", BodyStats(0, 83, "blue", Option(false),Seq(36.6, 36.7, 37.0, 36.6)), Seq(
-        ErrorMessage.stdCastErr("body stats.height", "various")
+        StandardizationErrorMessage.stdCastErr("body stats.height", "various")
       )),
       PatientRow("Aldrich", "Killian", BodyStats(181, 90, "brown or orange", None, Seq(36.7, 36.5, 38.0, 48.0, 152.0, 831.0, 0.0)), Seq(
-        ErrorMessage.stdCastErr("body stats.miscellaneous.glasses", "not any more"),
-        ErrorMessage.stdCastErr("body stats.temperature measurements[*]", "exploded")
+        StandardizationErrorMessage.stdCastErr("body stats.miscellaneous.glasses", "not any more"),
+        StandardizationErrorMessage.stdCastErr("body stats.temperature measurements[*]", "exploded")
       ))
     )
 

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_BinarySuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_BinarySuite.scala
@@ -19,12 +19,13 @@ package za.co.absa.standardization.interpreter
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import za.co.absa.spark.commons.errorhandling.ErrorMessage
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
 import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig}
-import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
+import za.co.absa.standardization.types.{CommonTypeDefaults, TypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
-import za.co.absa.standardization.{ErrorMessage, LoggerTestBase, Standardization, ValidationException}
+import za.co.absa.standardization.{LoggerTestBase, Standardization, ValidationException}
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_BinarySuite extends AnyFunSuite with SparkTestBase with LoggerTestBase with Matchers {

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
@@ -22,9 +22,9 @@ import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
 import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
-import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
+import za.co.absa.standardization.types.{CommonTypeDefaults, TypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
-import za.co.absa.standardization.{ErrorMessage, LoggerTestBase, Standardization}
+import za.co.absa.standardization.{LoggerTestBase, Standardization, StandardizationErrorMessage}
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
@@ -167,8 +167,8 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
       DateRow(Date.valueOf("1970-01-02")),
       DateRow(Date.valueOf("2000-12-31")),
       DateRow(Date.valueOf("2019-07-16")),
-      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "1970-02-02"))),
-      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "crash")))
+      DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "1970-02-02"))),
+      DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "crash")))
     )
 
     val src = seq.toDF(fieldName)
@@ -197,8 +197,8 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
       DateRow(Date.valueOf("1970-01-02")),
       DateRow(Date.valueOf("2000-12-31")),
       DateRow(Date.valueOf("2019-07-16")),
-      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "00-75-00 03.01.1970 EET"))),
-      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "crash")))
+      DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "00-75-00 03.01.1970 EET"))),
+      DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "crash")))
     )
 
     val src = seq.toDF(fieldName)
@@ -228,8 +228,8 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
       DateRow(Date.valueOf("1970-01-02")),
       DateRow(Date.valueOf("2000-12-31")),
       DateRow(Date.valueOf("2019-07-16")),
-      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "00:75:00(001002003) 03+01+1970 +02:00"))),
-      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "crash")))
+      DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "00:75:00(001002003) 03+01+1970 +02:00"))),
+      DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "crash")))
     )
 
     val src = seq.toDF(fieldName)
@@ -261,8 +261,8 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
       DateRow(Date.valueOf("1970-01-02")),
       DateRow(Date.valueOf("2000-12-31")),
       DateRow(Date.valueOf("2019-07-16")),
-      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "1970-02-02"))),
-      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "crash")))
+      DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "1970-02-02"))),
+      DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "crash")))
     )
 
     val src = seq.toDF(fieldName)
@@ -295,8 +295,8 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
       DateRow(Date.valueOf("1970-01-01")),
       DateRow(Date.valueOf("2000-12-30")),
       DateRow(Date.valueOf("2019-07-15")),
-      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "1970-02-02"))),
-      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "crash")))
+      DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "1970-02-02"))),
+      DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "crash")))
     )
 
     val src = seq.toDF(fieldName)
@@ -326,9 +326,9 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
       DateRow(Date.valueOf("1970-02-01")),
       DateRow(Date.valueOf("2000-12-31")),
       DateRow(Date.valueOf("2019-07-16")),
-      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "02 3 of 1970"))),
-      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "February 4 1970"))),
-      DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "crash")))
+      DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "02 3 of 1970"))),
+      DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "February 4 1970"))),
+      DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "crash")))
     )
 
     val src = seq.toDF(fieldName)
@@ -358,8 +358,8 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
     DateRow(Date.valueOf("1970-02-01")),
     DateRow(Date.valueOf("2000-12-31")),
     DateRow(Date.valueOf("2019-07-16")),
-    DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "1970/02/02 insignificant "))),
-    DateRow(Date.valueOf("1970-01-01"), Seq(ErrorMessage.stdCastErr(fieldName, "crash")))
+    DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "1970/02/02 insignificant "))),
+    DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "crash")))
   )
 
   val src = seq.toDF(fieldName)

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
@@ -18,13 +18,14 @@ package za.co.absa.standardization.interpreter
 
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.spark.commons.errorhandling.ErrorMessage
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
 import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
 import za.co.absa.standardization.schema.MetadataKeys
-import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
+import za.co.absa.standardization.types.{CommonTypeDefaults, TypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
-import za.co.absa.standardization.{ErrorMessage, LoggerTestBase, Standardization}
+import za.co.absa.standardization.{LoggerTestBase, Standardization, StandardizationErrorMessage}
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
@@ -42,7 +43,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
   private implicit val defaults: TypeDefaults = CommonTypeDefaults
 
   private def err(value: String, cnt: Int): Seq[ErrorMessage] = {
-    val item = ErrorMessage.stdCastErr("src",value)
+    val item = StandardizationErrorMessage.stdCastErr("src",value)
     val array = Array.fill(cnt) (item)
     array.toList
   }
@@ -84,21 +85,21 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
     val exp = Seq(
       FractionalRow("01-Pi", Option(3.14F), Option(3.14)),
       FractionalRow("02-Null", Option(0), None, Seq(
-        ErrorMessage.stdNullErr("floatField"))),
+        StandardizationErrorMessage.stdNullErr("floatField"))),
       FractionalRow("03-Long", Option(9.223372E18F), Option(-9.223372036854776E18)),
       FractionalRow("04-infinity", Option(0), None, Seq(
-        ErrorMessage.stdCastErr("floatField", "-Infinity"),
-        ErrorMessage.stdCastErr("doubleField", "Infinity"))),
+        StandardizationErrorMessage.stdCastErr("floatField", "-Infinity"),
+        StandardizationErrorMessage.stdCastErr("doubleField", "Infinity"))),
       FractionalRow("05-Really big", Option(0), None, Seq(
-        ErrorMessage.stdCastErr("floatField", "123456789123456791245678912324789123456789123456789.12"),
-        ErrorMessage.stdCastErr("doubleField", "12345678912345679124567891232478912345678912345678912"
+        StandardizationErrorMessage.stdCastErr("floatField", "123456789123456791245678912324789123456789123456789.12"),
+        StandardizationErrorMessage.stdCastErr("doubleField", "12345678912345679124567891232478912345678912345678912"
           + "3456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789123456789"
           + "1234567891234567891234567891234567891234567891234678912345678912345678912345678912345679124567891232478912"
           + "3456789123456789123456789123456789123456791245678912324789123456789123456789123456789123456789123456789123"
           + "456789123456789.1"))),
       FractionalRow("06-Text", Option(0), None, Seq(
-        ErrorMessage.stdCastErr("floatField", "foo"),
-        ErrorMessage.stdCastErr("doubleField", "bar"))),
+        StandardizationErrorMessage.stdCastErr("floatField", "foo"),
+        StandardizationErrorMessage.stdCastErr("doubleField", "bar"))),
       FractionalRow("07-Exponential notation", Option(-12300.0f), Option(0.0098765))
     )
 
@@ -117,7 +118,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
 
     val exp = Seq(
       FractionalRow("01-Null", Option(0), None, Seq(
-        ErrorMessage.stdNullErr("floatField"))),
+        StandardizationErrorMessage.stdNullErr("floatField"))),
       FractionalRow("02-Big Long", Option(9.223372E18F), Option(-9.223372036854776E18)), //NBN! the loss of precision
       FractionalRow("03-Long", Option(-value.toFloat), Option(value.toDouble))
     )
@@ -144,16 +145,16 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
     val exp = Seq(
       FractionalRow("01-Pi", Option(Math.PI.toFloat), Option(Math.PI)),
       FractionalRow("02-Null", Option(0), None, Seq(
-        ErrorMessage.stdNullErr("floatField"))),
+        StandardizationErrorMessage.stdNullErr("floatField"))),
       FractionalRow("03-Long", Option(9.223372E18F), Option(-9.223372036854776E18)),
       FractionalRow("04-Infinity", Option(0), None, Seq(
-        ErrorMessage.stdCastErr("floatField", "-Infinity"),
-        ErrorMessage.stdCastErr("doubleField", "Infinity"))),
+        StandardizationErrorMessage.stdCastErr("floatField", "-Infinity"),
+        StandardizationErrorMessage.stdCastErr("doubleField", "Infinity"))),
       FractionalRow("05-Really big", Option(0), Option(reallyBig), Seq(
-        ErrorMessage.stdCastErr("floatField", reallyBig.toString))),
+        StandardizationErrorMessage.stdCastErr("floatField", reallyBig.toString))),
       FractionalRow("06-NaN", Option(0), None, Seq(
-        ErrorMessage.stdCastErr("floatField", "NaN"),
-        ErrorMessage.stdCastErr("doubleField", "NaN")))
+        StandardizationErrorMessage.stdCastErr("floatField", "NaN"),
+        StandardizationErrorMessage.stdCastErr("doubleField", "NaN")))
     )
 
     val std = Standardization.standardize(src, desiredSchema, stdConfig).cacheIfNotCachedYet()
@@ -185,13 +186,13 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
     val exp = Seq(
       FractionalRow("01-Euler", Option(2.71F), Option(2.71)),
       FractionalRow("02-Null", Option(0), None, Seq(
-        ErrorMessage.stdNullErr("floatField"))),
+        StandardizationErrorMessage.stdNullErr("floatField"))),
       FractionalRow("03-Long", Option(9.223372E18F), Option(-9.223372036854776E18)),
       FractionalRow("04-infinity", Some(Float.NegativeInfinity), Option(Double.PositiveInfinity)),
       FractionalRow("05-Really big", Option(Float.PositiveInfinity), Option(Double.NegativeInfinity)),
       FractionalRow("06-Text", Option(0), None, Seq(
-        ErrorMessage.stdCastErr("floatField", "foo"),
-        ErrorMessage.stdCastErr("doubleField", "bar"))),
+        StandardizationErrorMessage.stdCastErr("floatField", "foo"),
+        StandardizationErrorMessage.stdCastErr("doubleField", "bar"))),
       FractionalRow("07-Exponential notation", Option(-12300.0f), Option(0.0098765))
     )
 
@@ -214,13 +215,13 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
     val exp = Seq(
       FractionalRow("01-Euler", Option(Math.E.toFloat), Option(Math.E)),
       FractionalRow("02-Null", Option(0), None, Seq(
-        ErrorMessage.stdNullErr("floatField"))),
+        StandardizationErrorMessage.stdNullErr("floatField"))),
       FractionalRow("03-Long", Option(9.223372E18F), Option(-9.223372036854776E18)),
       FractionalRow("04-Infinity", Option(Float.NegativeInfinity), Option(Double.PositiveInfinity)),
       FractionalRow("05-Really big", Option(Float.PositiveInfinity), Option(reallyBig)),
       FractionalRow("06-NaN", Option(0), None, Seq(
-        ErrorMessage.stdCastErr("floatField", "NaN"),
-        ErrorMessage.stdCastErr("doubleField", "NaN")))
+        StandardizationErrorMessage.stdCastErr("floatField", "NaN"),
+        StandardizationErrorMessage.stdCastErr("doubleField", "NaN")))
     )
 
     val std = Standardization.standardize(src, desiredSchemaWithInfinity, stdConfig).cacheIfNotCachedYet()
@@ -289,7 +290,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
     val exp = List(
       ("01-Positive", "+3", 3.0F, Some(3.0D), Some(3.0F), 3.0D, Seq.empty),
       ("02-Negative", "~8123,4", -8123.4F, Some(-8123.4D), Some(-8123.4F), -8123.4D, Seq.empty),
-      ("03-Null", null, 0F, None, None, 0D, Array.fill(2)(ErrorMessage.stdNullErr("src")).toList),
+      ("03-Null", null, 0F, None, None, 0D, Array.fill(2)(StandardizationErrorMessage.stdNullErr("src")).toList),
       ("04-Big", "7899012345678901234567890123456789012346789,123456789", 0F, Some(7.899012345678901E42D), Some(Float.PositiveInfinity), 7.899012345678901E42,
         err("7899012345678901234567890123456789012346789,123456789", 1)
       ),
@@ -374,7 +375,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
     val exp = List(
       ("01-Positive", "+3°", 3.0F, Some(3.0D), Some(3.0F), 3.0D, Seq.empty),
       ("02-Negative", "(8 123,4°)", -8123.4F, Some(-8123.4D), Some(-8123.4F), -8123.4D, Seq.empty),
-      ("03-Null", null, 0F, None, None, 0D, Array.fill(2)(ErrorMessage.stdNullErr("src")).toList),
+      ("03-Null", null, 0F, None, None, 0D, Array.fill(2)(StandardizationErrorMessage.stdNullErr("src")).toList),
       ("04-Big", "+789 9012 345 678 901 234 567 890 123 456 789 012 346 789,123456789°", 0F, Some(7.899012345678901E42D), Some(Float.PositiveInfinity), 7.899012345678901E42,
         err("+789 9012 345 678 901 234 567 890 123 456 789 012 346 789,123456789°", 1)
       ),

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_IntegralSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_IntegralSuite.scala
@@ -20,14 +20,15 @@ import java.text.{DecimalFormat, NumberFormat}
 import java.util.Locale
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.spark.commons.errorhandling.ErrorMessage
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
 import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
 import za.co.absa.standardization.schema.MetadataKeys
-import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
+import za.co.absa.standardization.types.{CommonTypeDefaults, TypeDefaults}
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.standardization.udf.UDFLibrary
-import za.co.absa.standardization.{ErrorMessage, LoggerTestBase, Standardization}
+import za.co.absa.standardization.{LoggerTestBase, Standardization, StandardizationErrorMessage}
 
 class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase{
 
@@ -62,7 +63,7 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
   ))
 
   private def err(value: String, cnt: Int): Seq[ErrorMessage] = {
-    val item = ErrorMessage.stdCastErr("src",value)
+    val item = StandardizationErrorMessage.stdCastErr("src",value)
     val array = Array.fill(cnt) (item)
     array.toList
   }
@@ -78,31 +79,31 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
 
     val exp = Seq(
       IntegralRow("Decimal entry", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", "1.0"),
-        ErrorMessage.stdCastErr("shortsize", "2.0"),
-        ErrorMessage.stdCastErr("integersize", "3.0"),
-        ErrorMessage.stdCastErr("longsize", "4.0"))),
+        StandardizationErrorMessage.stdCastErr("bytesize", "1.0"),
+        StandardizationErrorMessage.stdCastErr("shortsize", "2.0"),
+        StandardizationErrorMessage.stdCastErr("integersize", "3.0"),
+        StandardizationErrorMessage.stdCastErr("longsize", "4.0"))),
       IntegralRow("Full negative", Option(-128), Option(-32768), Option(-2147483648), Option(-9223372036854775808L)),
       IntegralRow("Full positive", Option(127), Option(32767), Option(2147483647), Option(9223372036854775807L)),
       IntegralRow("Nulls", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdNullErr("bytesize"),
-        ErrorMessage.stdNullErr("shortsize"))),
+        StandardizationErrorMessage.stdNullErr("bytesize"),
+        StandardizationErrorMessage.stdNullErr("shortsize"))),
       IntegralRow("One", Option(1), Option(1), Option(1), Option(1)),
       IntegralRow("Overflow", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", "128"),
-        ErrorMessage.stdCastErr("shortsize", "32768"),
-        ErrorMessage.stdCastErr("integersize", "2147483648"),
-        ErrorMessage.stdCastErr("longsize", "9223372036854775808"))),
+        StandardizationErrorMessage.stdCastErr("bytesize", "128"),
+        StandardizationErrorMessage.stdCastErr("shortsize", "32768"),
+        StandardizationErrorMessage.stdCastErr("integersize", "2147483648"),
+        StandardizationErrorMessage.stdCastErr("longsize", "9223372036854775808"))),
       IntegralRow("Underflow", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", "-129"),
-        ErrorMessage.stdCastErr("shortsize", "-32769"),
-        ErrorMessage.stdCastErr("integersize", "-2147483649"),
-        ErrorMessage.stdCastErr("longsize", "-9223372036854775809"))),
+        StandardizationErrorMessage.stdCastErr("bytesize", "-129"),
+        StandardizationErrorMessage.stdCastErr("shortsize", "-32769"),
+        StandardizationErrorMessage.stdCastErr("integersize", "-2147483649"),
+        StandardizationErrorMessage.stdCastErr("longsize", "-9223372036854775809"))),
       IntegralRow("With fractions", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", "3.14"),
-        ErrorMessage.stdCastErr("shortsize", "2.71"),
-        ErrorMessage.stdCastErr("integersize", "1.41"),
-        ErrorMessage.stdCastErr("longsize", "1.5"))),
+        StandardizationErrorMessage.stdCastErr("bytesize", "3.14"),
+        StandardizationErrorMessage.stdCastErr("shortsize", "2.71"),
+        StandardizationErrorMessage.stdCastErr("integersize", "1.41"),
+        StandardizationErrorMessage.stdCastErr("longsize", "1.5"))),
       IntegralRow("With plus sign", Option(127), Option(32767), Option(2147483647), Option(9223372036854775807L)),
       IntegralRow("With zeros", Option(0), Option(7), Option(-1), Option(0))
     )
@@ -118,31 +119,31 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
 
     val exp = Seq(
       IntegralRow("Decimal entry", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", "1.0"),
-        ErrorMessage.stdCastErr("shortsize", "2.0"),
-        ErrorMessage.stdCastErr("integersize", "3.0"),
-        ErrorMessage.stdCastErr("longsize", "4.0"))),
+        StandardizationErrorMessage.stdCastErr("bytesize", "1.0"),
+        StandardizationErrorMessage.stdCastErr("shortsize", "2.0"),
+        StandardizationErrorMessage.stdCastErr("integersize", "3.0"),
+        StandardizationErrorMessage.stdCastErr("longsize", "4.0"))),
       IntegralRow("Full negative", Option(-128), Option(-32768), Option(-2147483648), Option(-9223372036854775808L)),
       IntegralRow("Full positive", Option(127), Option(32767), Option(2147483647), Option(9223372036854775807L)),
       IntegralRow("Nulls", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdNullErr("bytesize"),
-        ErrorMessage.stdNullErr("shortsize"))),
+        StandardizationErrorMessage.stdNullErr("bytesize"),
+        StandardizationErrorMessage.stdNullErr("shortsize"))),
       IntegralRow("One", Option(1), Option(1), Option(1), Option(1)),
       IntegralRow("Overflow", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", "128"),
-        ErrorMessage.stdCastErr("shortsize", "32768"),
-        ErrorMessage.stdCastErr("integersize", "2147483648"),
-        ErrorMessage.stdCastErr("longsize", "9223372036854775808"))),
+        StandardizationErrorMessage.stdCastErr("bytesize", "128"),
+        StandardizationErrorMessage.stdCastErr("shortsize", "32768"),
+        StandardizationErrorMessage.stdCastErr("integersize", "2147483648"),
+        StandardizationErrorMessage.stdCastErr("longsize", "9223372036854775808"))),
       IntegralRow("Underflow", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", "-129"),
-        ErrorMessage.stdCastErr("shortsize", "-32769"),
-        ErrorMessage.stdCastErr("integersize", "-2147483649"),
-        ErrorMessage.stdCastErr("longsize", "-9223372036854775809"))),
+        StandardizationErrorMessage.stdCastErr("bytesize", "-129"),
+        StandardizationErrorMessage.stdCastErr("shortsize", "-32769"),
+        StandardizationErrorMessage.stdCastErr("integersize", "-2147483649"),
+        StandardizationErrorMessage.stdCastErr("longsize", "-9223372036854775809"))),
       IntegralRow("With fractions", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", "3.14"),
-        ErrorMessage.stdCastErr("shortsize", "2.71"),
-        ErrorMessage.stdCastErr("integersize", "1.41"),
-        ErrorMessage.stdCastErr("longsize", "1.5"))),
+        StandardizationErrorMessage.stdCastErr("bytesize", "3.14"),
+        StandardizationErrorMessage.stdCastErr("shortsize", "2.71"),
+        StandardizationErrorMessage.stdCastErr("integersize", "1.41"),
+        StandardizationErrorMessage.stdCastErr("longsize", "1.5"))),
       IntegralRow("With plus sign", Option(127), Option(32767), Option(2147483647), Option(9223372036854775807L)),
       IntegralRow("With zeros", Option(0), Option(7), Option(-1), Option(0))
     )
@@ -158,25 +159,25 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
 
     val exp = Seq(
       IntegralRow("Decimal entry", Option(0), Option(2), Option(3), Option(4), Seq(
-        ErrorMessage.stdCastErr("bytesize", "1.1"))),
+        StandardizationErrorMessage.stdCastErr("bytesize", "1.1"))),
       IntegralRow("Full negative", Option(-128), Option(-32768), Option(-2147483648), None, Seq(
-        ErrorMessage.stdCastErr("longsize", "-9223372036854776000"))),
+        StandardizationErrorMessage.stdCastErr("longsize", "-9223372036854776000"))),
       IntegralRow("Full positive", Option(127), Option(32767), Option(2147483647), None, Seq(
-        ErrorMessage.stdCastErr("longsize", "9223372036854776000"))),
+        StandardizationErrorMessage.stdCastErr("longsize", "9223372036854776000"))),
       IntegralRow("Nulls", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdNullErr("bytesize"),
-        ErrorMessage.stdNullErr("shortsize"))),
+        StandardizationErrorMessage.stdNullErr("bytesize"),
+        StandardizationErrorMessage.stdNullErr("shortsize"))),
       IntegralRow("One", Option(1), Option(1), Option(1), Option(1)),
       IntegralRow("Overflow", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", "128.0"),
-        ErrorMessage.stdCastErr("shortsize", "32768"),
-        ErrorMessage.stdCastErr("integersize", "2147483648"),
-        ErrorMessage.stdCastErr("longsize", "9223372036854776000"))),
+        StandardizationErrorMessage.stdCastErr("bytesize", "128.0"),
+        StandardizationErrorMessage.stdCastErr("shortsize", "32768"),
+        StandardizationErrorMessage.stdCastErr("integersize", "2147483648"),
+        StandardizationErrorMessage.stdCastErr("longsize", "9223372036854776000"))),
       IntegralRow("Underflow", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", "-129.0"),
-        ErrorMessage.stdCastErr("shortsize", "-32769"),
-        ErrorMessage.stdCastErr("integersize", "-2147483649"),
-        ErrorMessage.stdCastErr("longsize", "-9223372036854776000")))
+        StandardizationErrorMessage.stdCastErr("bytesize", "-129.0"),
+        StandardizationErrorMessage.stdCastErr("shortsize", "-32769"),
+        StandardizationErrorMessage.stdCastErr("integersize", "-2147483649"),
+        StandardizationErrorMessage.stdCastErr("longsize", "-9223372036854776000")))
     )
     assertResult(exp)(std.as[IntegralRow].collect().sortBy(_.description).toList)
   }
@@ -200,24 +201,24 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
     val exp = Seq(
       IntegralRow("1-Byte", Option(Byte.MaxValue), Option(Byte.MaxValue), Option(Byte.MaxValue), Option(Byte.MaxValue)),
       IntegralRow("2-Short", Option(0), Option(Short.MaxValue), Option(Short.MaxValue), Option(Short.MaxValue), Seq(
-        ErrorMessage.stdCastErr("bytesize", Short.MaxValue.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", Short.MaxValue.toString))),
       IntegralRow("3-Int", Option(0), Option(0), Option(Int.MaxValue), Option(Int.MaxValue), Seq(
-        ErrorMessage.stdCastErr("bytesize", Int.MaxValue.toString),
-        ErrorMessage.stdCastErr("shortsize", Int.MaxValue.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", Int.MaxValue.toString),
+        StandardizationErrorMessage.stdCastErr("shortsize", Int.MaxValue.toString))),
       IntegralRow("4-Long", Option(0), Option(0), None, Option(Long.MaxValue), Seq(
-        ErrorMessage.stdCastErr("bytesize", Long.MaxValue.toString),
-        ErrorMessage.stdCastErr("shortsize", Long.MaxValue.toString),
-        ErrorMessage.stdCastErr("integersize", Long.MaxValue.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", Long.MaxValue.toString),
+        StandardizationErrorMessage.stdCastErr("shortsize", Long.MaxValue.toString),
+        StandardizationErrorMessage.stdCastErr("integersize", Long.MaxValue.toString))),
       IntegralRow("5-Byte", Option(Byte.MinValue), Option(Byte.MinValue), Option(Byte.MinValue), Option(Byte.MinValue)),
       IntegralRow("6-Short", Option(0), Option(Short.MinValue), Option(Short.MinValue), Option(Short.MinValue), Seq(
-        ErrorMessage.stdCastErr("bytesize", Short.MinValue.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", Short.MinValue.toString))),
       IntegralRow("7-Int", Option(0), Option(0), Option(Int.MinValue), Option(Int.MinValue), Seq(
-        ErrorMessage.stdCastErr("bytesize", Int.MinValue.toString),
-        ErrorMessage.stdCastErr("shortsize", Int.MinValue.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", Int.MinValue.toString),
+        StandardizationErrorMessage.stdCastErr("shortsize", Int.MinValue.toString))),
       IntegralRow("8-Long", Option(0), Option(0), None, Option(Long.MinValue), Seq(
-        ErrorMessage.stdCastErr("bytesize", Long.MinValue.toString),
-        ErrorMessage.stdCastErr("shortsize", Long.MinValue.toString),
-        ErrorMessage.stdCastErr("integersize", Long.MinValue.toString)))
+        StandardizationErrorMessage.stdCastErr("bytesize", Long.MinValue.toString),
+        StandardizationErrorMessage.stdCastErr("shortsize", Long.MinValue.toString),
+        StandardizationErrorMessage.stdCastErr("integersize", Long.MinValue.toString)))
     )
     assertResult(exp)(std.as[IntegralRow].collect().sortBy(_.description).toList)
   }
@@ -255,53 +256,53 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
       IntegralRow("00-One", Option(1), Option(1), Option(1), Option(1)),
       IntegralRow("01-Byte", Option(Byte.MaxValue), Option(Byte.MaxValue), Option(Byte.MaxValue), Option(Byte.MaxValue)),
       IntegralRow("02-Short", Option(0), Option(Short.MaxValue), Option(Short.MaxValue), Option(Short.MaxValue), Seq(
-        ErrorMessage.stdCastErr("bytesize", Short.MaxValue.toDouble.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", Short.MaxValue.toDouble.toString))),
       IntegralRow("03-Int", Option(0), Option(0), Option(Int.MaxValue), Option(Int.MaxValue), Seq(
-        ErrorMessage.stdCastErr("bytesize", Int.MaxValue.toDouble.toString),
-        ErrorMessage.stdCastErr("shortsize", Int.MaxValue.toDouble.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", Int.MaxValue.toDouble.toString),
+        StandardizationErrorMessage.stdCastErr("shortsize", Int.MaxValue.toDouble.toString))),
       IntegralRow("04-Long", Option(0), Option(0), None, Option(Long.MaxValue), Seq(
-        ErrorMessage.stdCastErr("bytesize", Long.MaxValue.toDouble.toString),
-        ErrorMessage.stdCastErr("shortsize", Long.MaxValue.toDouble.toString),
-        ErrorMessage.stdCastErr("integersize", Long.MaxValue.toDouble.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", Long.MaxValue.toDouble.toString),
+        StandardizationErrorMessage.stdCastErr("shortsize", Long.MaxValue.toDouble.toString),
+        StandardizationErrorMessage.stdCastErr("integersize", Long.MaxValue.toDouble.toString))),
       IntegralRow("05-Byte", Option(Byte.MinValue), Option(Byte.MinValue), Option(Byte.MinValue), Option(Byte.MinValue)),
       IntegralRow("06-Short", Option(0), Option(Short.MinValue), Option(Short.MinValue), Option(Short.MinValue), Seq(
-        ErrorMessage.stdCastErr("bytesize", Short.MinValue.toDouble.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", Short.MinValue.toDouble.toString))),
       IntegralRow("07-Int", Option(0), Option(0), Option(Int.MinValue), Option(Int.MinValue), Seq(
-        ErrorMessage.stdCastErr("bytesize", Int.MinValue.toDouble.toString),
-        ErrorMessage.stdCastErr("shortsize", Int.MinValue.toDouble.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", Int.MinValue.toDouble.toString),
+        StandardizationErrorMessage.stdCastErr("shortsize", Int.MinValue.toDouble.toString))),
       IntegralRow("08-Long", Option(0), Option(0), None, Option(Long.MinValue), Seq(
-        ErrorMessage.stdCastErr("bytesize", Long.MinValue.toDouble.toString),
-        ErrorMessage.stdCastErr("shortsize", Long.MinValue.toDouble.toString),
-        ErrorMessage.stdCastErr("integersize", Long.MinValue.toDouble.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", Long.MinValue.toDouble.toString),
+        StandardizationErrorMessage.stdCastErr("shortsize", Long.MinValue.toDouble.toString),
+        StandardizationErrorMessage.stdCastErr("integersize", Long.MinValue.toDouble.toString))),
       IntegralRow("09-Pi", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", Math.PI.toString),
-        ErrorMessage.stdCastErr("shortsize", Math.PI.toString),
-        ErrorMessage.stdCastErr("integersize", Math.PI.toString),
-        ErrorMessage.stdCastErr("longsize", Math.PI.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", Math.PI.toString),
+        StandardizationErrorMessage.stdCastErr("shortsize", Math.PI.toString),
+        StandardizationErrorMessage.stdCastErr("integersize", Math.PI.toString),
+        StandardizationErrorMessage.stdCastErr("longsize", Math.PI.toString))),
       IntegralRow("10-Whole", Option(7), Option(7), Option(7), Option(7)),
       IntegralRow("11-Really small", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", Double.MinPositiveValue.toString),
-        ErrorMessage.stdCastErr("shortsize", Double.MinPositiveValue.toString),
-        ErrorMessage.stdCastErr("integersize", Double.MinPositiveValue.toString),
-        ErrorMessage.stdCastErr("longsize", Double.MinPositiveValue.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", Double.MinPositiveValue.toString),
+        StandardizationErrorMessage.stdCastErr("shortsize", Double.MinPositiveValue.toString),
+        StandardizationErrorMessage.stdCastErr("integersize", Double.MinPositiveValue.toString),
+        StandardizationErrorMessage.stdCastErr("longsize", Double.MinPositiveValue.toString))),
       IntegralRow("12-Really big", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", reallyBig.toString),
-        ErrorMessage.stdCastErr("shortsize", reallyBig.toString),
-        ErrorMessage.stdCastErr("integersize", reallyBig.toString),
-        ErrorMessage.stdCastErr("longsize", reallyBig.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", reallyBig.toString),
+        StandardizationErrorMessage.stdCastErr("shortsize", reallyBig.toString),
+        StandardizationErrorMessage.stdCastErr("integersize", reallyBig.toString),
+        StandardizationErrorMessage.stdCastErr("longsize", reallyBig.toString))),
       IntegralRow("13-Tiny fractional part", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", tinyFractionalPart.toString),
-        ErrorMessage.stdCastErr("shortsize", tinyFractionalPart.toString),
-        ErrorMessage.stdCastErr("integersize", tinyFractionalPart.toString),
-        ErrorMessage.stdCastErr("longsize", tinyFractionalPart.toString))),
+        StandardizationErrorMessage.stdCastErr("bytesize", tinyFractionalPart.toString),
+        StandardizationErrorMessage.stdCastErr("shortsize", tinyFractionalPart.toString),
+        StandardizationErrorMessage.stdCastErr("integersize", tinyFractionalPart.toString),
+        StandardizationErrorMessage.stdCastErr("longsize", tinyFractionalPart.toString))),
       IntegralRow("14-NaN", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", "NaN"),
-        ErrorMessage.stdCastErr("shortsize", "NaN"),
-        ErrorMessage.stdCastErr("integersize", "NaN"),
-        ErrorMessage.stdCastErr("longsize", "NaN"))),
+        StandardizationErrorMessage.stdCastErr("bytesize", "NaN"),
+        StandardizationErrorMessage.stdCastErr("shortsize", "NaN"),
+        StandardizationErrorMessage.stdCastErr("integersize", "NaN"),
+        StandardizationErrorMessage.stdCastErr("longsize", "NaN"))),
       IntegralRow("15-Null", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdNullErr("bytesize"),
-        ErrorMessage.stdNullErr("shortsize")))
+        StandardizationErrorMessage.stdNullErr("bytesize"),
+        StandardizationErrorMessage.stdNullErr("shortsize")))
     )
 
     assertResult(exp)(std.as[IntegralRow].collect().sortBy(_.description).toList)
@@ -341,31 +342,31 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
     val exp = Seq(
       IntegralRow("00-One", Option(1), Option(1), Option(1), Option(1)),
       IntegralRow("01-Pi", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", formatBigDecimal(pi)),
-        ErrorMessage.stdCastErr("shortsize", formatBigDecimal(pi)),
-        ErrorMessage.stdCastErr("integersize", formatBigDecimal(pi)),
-        ErrorMessage.stdCastErr("longsize", formatBigDecimal(pi)))),
+        StandardizationErrorMessage.stdCastErr("bytesize", formatBigDecimal(pi)),
+        StandardizationErrorMessage.stdCastErr("shortsize", formatBigDecimal(pi)),
+        StandardizationErrorMessage.stdCastErr("integersize", formatBigDecimal(pi)),
+        StandardizationErrorMessage.stdCastErr("longsize", formatBigDecimal(pi)))),
       IntegralRow("02-Tiny fractional part", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", tinyFractionalPartStr),
-        ErrorMessage.stdCastErr("shortsize", tinyFractionalPartStr),
-        ErrorMessage.stdCastErr("integersize", tinyFractionalPartStr),
-        ErrorMessage.stdCastErr("longsize", tinyFractionalPartStr))),
+        StandardizationErrorMessage.stdCastErr("bytesize", tinyFractionalPartStr),
+        StandardizationErrorMessage.stdCastErr("shortsize", tinyFractionalPartStr),
+        StandardizationErrorMessage.stdCastErr("integersize", tinyFractionalPartStr),
+        StandardizationErrorMessage.stdCastErr("longsize", tinyFractionalPartStr))),
       IntegralRow("03-Really big", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", reallyBigStr),
-        ErrorMessage.stdCastErr("shortsize", reallyBigStr),
-        ErrorMessage.stdCastErr("integersize", reallyBigStr),
-        ErrorMessage.stdCastErr("longsize", reallyBigStr))),
+        StandardizationErrorMessage.stdCastErr("bytesize", reallyBigStr),
+        StandardizationErrorMessage.stdCastErr("shortsize", reallyBigStr),
+        StandardizationErrorMessage.stdCastErr("integersize", reallyBigStr),
+        StandardizationErrorMessage.stdCastErr("longsize", reallyBigStr))),
       IntegralRow("04-Really small", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdCastErr("bytesize", reallySmallStr),
-        ErrorMessage.stdCastErr("shortsize", reallySmallStr),
-        ErrorMessage.stdCastErr("integersize", reallySmallStr),
-        ErrorMessage.stdCastErr("longsize", reallySmallStr))),
+        StandardizationErrorMessage.stdCastErr("bytesize", reallySmallStr),
+        StandardizationErrorMessage.stdCastErr("shortsize", reallySmallStr),
+        StandardizationErrorMessage.stdCastErr("integersize", reallySmallStr),
+        StandardizationErrorMessage.stdCastErr("longsize", reallySmallStr))),
       IntegralRow("05-Short", Option(0), Option(0), Option(Short.MaxValue + 1), Option(Short.MaxValue + 1), Seq(
-        ErrorMessage.stdCastErr("bytesize", formatBigDecimal(shortOverflow)),
-        ErrorMessage.stdCastErr("shortsize", formatBigDecimal(shortOverflow)))),
+        StandardizationErrorMessage.stdCastErr("bytesize", formatBigDecimal(shortOverflow)),
+        StandardizationErrorMessage.stdCastErr("shortsize", formatBigDecimal(shortOverflow)))),
       IntegralRow("06-Null", Option(0), Option(0), None, None, Seq(
-        ErrorMessage.stdNullErr("bytesize"),
-        ErrorMessage.stdNullErr("shortsize")))
+        StandardizationErrorMessage.stdNullErr("bytesize"),
+        StandardizationErrorMessage.stdNullErr("shortsize")))
     )
 
     assertResult(exp)(std.as[IntegralRow].collect().sortBy(_.description).toList)
@@ -421,7 +422,7 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
 
     val exp = List(
       ("01-Normal", "3", 3, Some(3), Some(3), 3, Seq.empty),
-      ("02-Null", null, 0, None, None, 1000, Array.fill(2)(ErrorMessage.stdNullErr(srcField)).toList),
+      ("02-Null", null, 0, None, None, 1000, Array.fill(2)(StandardizationErrorMessage.stdNullErr(srcField)).toList),
       ("03-Far negative", "^100000000", 0, Some(-1), Some(-100000000), -100000000, err("^100000000", 2)),
       ("04-Wrong", "hello", 0, Some(-1), None, 1000, err("hello", 4))
     )
@@ -485,7 +486,7 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
 
     val exp = List(
       ("01-Normal", "3 feet", 3, Some(3), Some(3), 3, Seq.empty),
-      ("02-Null", null, 0, None, None, 1000, Array.fill(2)(ErrorMessage.stdNullErr(srcField)).toList),
+      ("02-Null", null, 0, None, None, 1000, Array.fill(2)(StandardizationErrorMessage.stdNullErr(srcField)).toList),
       ("03-Far negative", "^100.000.000 feet", 0, Some(-1), Some(-100000000), -100000000, err("^100.000.000 feet", 2)),
       ("04-Wrong", "hello", 0, Some(-1), None, 1000, err("hello", 4)),
       ("05-Not adhering to pattern", "123,456,789 feet", 0, Some(-1), None, 1000, err("123,456,789 feet", 4))
@@ -545,7 +546,7 @@ class StandardizationInterpreter_IntegralSuite extends AnyFunSuite with SparkTes
     logDataFrameContent(std)
 
     val exp = List(
-      ("00-Null"             , null   , 0 , None      , None       , 7651   , Array.fill(2)(ErrorMessage.stdNullErr(srcField)).toList),
+      ("00-Null"             , null   , 0 , None      , None       , 7651   , Array.fill(2)(StandardizationErrorMessage.stdNullErr(srcField)).toList),
       ("01-Binary"           , "+1101", 13, Some(393) , Some(4353) , 20413  , Seq.empty),
       ("02-Binary negative"  , "§1001", -9, Some(-344), Some(-4097), -19684 , Seq.empty),
       ("03-Septary"          , "35"   , 0 , Some(26)  , Some(53)   , 86     , err("35", 1)),

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
@@ -22,9 +22,9 @@ import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
 import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
-import za.co.absa.standardization.types.{TypeDefaults, CommonTypeDefaults}
+import za.co.absa.standardization.types.{CommonTypeDefaults, TypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
-import za.co.absa.standardization.{ErrorMessage, LoggerTestBase, Standardization}
+import za.co.absa.standardization.{LoggerTestBase, Standardization, StandardizationErrorMessage}
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
@@ -88,7 +88,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
       TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.99905")),
       TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43.123005")),
       TimestampRow(Timestamp.valueOf("1969-12-31 00:00:00")),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "Fail")))
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "Fail")))
     )
 
     val src = seq.toDF(fieldName)
@@ -169,8 +169,8 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
       TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00")),
       TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59")),
       TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43")),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "02.02.1970_00-00-00"))),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "nope")))
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "02.02.1970_00-00-00"))),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "nope")))
     )
 
     val src = seq.toDF(fieldName)
@@ -204,8 +204,8 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
       TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59")),
       TimestampRow(Timestamp.valueOf("2004-02-29 05:00:00")),
       TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43")),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "02.02.1970_24-00-00"))),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "nope")))
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "02.02.1970_24-00-00"))),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "nope")))
     )
 
     val src = seq.toDF(fieldName)
@@ -234,8 +234,8 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
       TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00.001")),
       TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.999")),
       TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43.123")),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "1970 02 02 00 00 00 112"))),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "nope")))
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "1970 02 02 00 00 00 112"))),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "nope")))
     )
 
     val src = seq.toDF(fieldName)
@@ -268,8 +268,8 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
       TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00.000001")),
       TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.999999")),
       TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43.123456")),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "02011970 010000 000001"))),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "nope")))
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "02011970 010000 000001"))),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "nope")))
     )
 
     val src = seq.toDF(fieldName)
@@ -299,8 +299,8 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
       TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00.001002")),
       TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.999999")),
       TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43.123456")),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "02/01/1970 00:00:00 001"))),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "nope")))
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "02/01/1970 00:00:00 001"))),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "nope")))
     )
 
     val src = seq.toDF(fieldName)
@@ -330,8 +330,8 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
       TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00.003001")),
       TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.999999")),
       TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43.123456")),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "(      ) 02/01/1970 01:00:00.000 CET"))),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "nope")))
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "(      ) 02/01/1970 01:00:00.000 CET"))),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "nope")))
     )
 
     val src = seq.toDF(fieldName)
@@ -362,8 +362,8 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
       TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00.003001")),
       TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59.999999")),
       TimestampRow(Timestamp.valueOf("1980-02-09 14:41:43.789123")),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "70002 staT [000] 12:00:00(aM) @000000"))),
-      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(ErrorMessage.stdCastErr(fieldName, "nope")))
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "70002 staT [000] 12:00:00(aM) @000000"))),
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "nope")))
     )
 
     val src = seq.toDF(fieldName)

--- a/src/test/scala/za/co/absa/standardization/interpreter/standardizationInterpreter_RowTypes.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/standardizationInterpreter_RowTypes.scala
@@ -16,9 +16,9 @@
 
 package za.co.absa.standardization.interpreter
 
-import java.sql.{Date, Timestamp}
+import za.co.absa.spark.commons.errorhandling.ErrorMessage
 
-import za.co.absa.standardization.ErrorMessage
+import java.sql.{Date, Timestamp}
 
 //Decimal Suite
 case class DecimalRow(description: String,


### PR DESCRIPTION
## Replacing error message with spark-common error message

Upgraded the spark-common version from 0.4.0 to 0.5.0
Removed ErrorMessage case class
Removed Mapping case class
Removed `errorColumnName` property
Removed `errorColSchema` method from the `data-standardization ErrorMessage` object
Renamed data-standardization `ErrorMessage file` and the Object to `StandardizationErrorMessage` and all associated call to this object
Refactored `csvContent property` value in `StandardizationCsvSuite`
Replaced data-standardization `ErrorMessages` with spark-common `ErrorMessages`

Closes #45