### PR TITLE
#61 Add infinity support to Dates and Numerics

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.10.2

--- a/src/main/scala/za/co/absa/standardization/schema/MetadataKeys.scala
+++ b/src/main/scala/za/co/absa/standardization/schema/MetadataKeys.scala
@@ -22,6 +22,10 @@ object MetadataKeys {
   val DefaultValue = "default"
   // date & timestamp
   val DefaultTimeZone = "timezone"
+  val MinusInfinitySymbol = "minus_infinity_symbol"
+  val MinusInfinityValue = "minus_infinity_value"
+  val PlusInfinitySymbol = "plus_infinity_symbol"
+  val PlusInfinityValue = "plus_infinity_value"
   // date & timestamp & all numeric
   val Pattern = "pattern"
   // all numeric

--- a/src/main/scala/za/co/absa/standardization/stages/InfinitySupport.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/InfinitySupport.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.standardization.stages
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions.{lit, when}
+import org.apache.spark.sql.types.DataType
+
+trait InfinitySupport {
+  protected def infMinusSymbol: Option[String]
+
+  protected def infMinusValue: Option[String]
+
+  protected def infPlusSymbol: Option[String]
+
+  protected def infPlusValue: Option[String]
+
+  protected val origType: DataType
+
+  def replaceInfinitySymbols(column: Column): Column = {
+    val columnWithNegativeInf: Column = infMinusSymbol.flatMap { minusSymbol =>
+      infMinusValue.map { minusValue =>
+        when(column === lit(minusSymbol).cast(origType), lit(minusValue).cast(origType)).otherwise(column)
+      }
+    }.getOrElse(column)
+
+    infPlusSymbol.flatMap { plusSymbol =>
+      infPlusValue.map { plusValue =>
+        when(columnWithNegativeInf === lit(plusSymbol).cast(origType), lit(plusValue).cast(origType))
+          .otherwise(columnWithNegativeInf)
+      }
+    }.getOrElse(columnWithNegativeInf)
+  }
+}

--- a/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
@@ -29,7 +29,6 @@ import za.co.absa.spark.hofs.transform
 import za.co.absa.standardization.{ErrorMessage, StandardizationErrorMessage}
 import za.co.absa.standardization.config.StandardizationConfig
 import za.co.absa.standardization.implicits.StdColumnImplicits.StdColumnEnhancements
-import za.co.absa.standardization.numeric.DecimalSymbols
 import za.co.absa.standardization.schema.StdSchemaUtils.FieldWithSource
 import za.co.absa.standardization.schema.{MetadataKeys, MetadataValues, StdSchemaUtils}
 import za.co.absa.standardization.time.DateTimePattern
@@ -692,29 +691,6 @@ object TypeParser {
         timestampColumn
       )
     }
-  }
-}
-
-sealed trait InfinitySupport {
-  protected def infMinusSymbol: Option[String]
-  protected def infMinusValue: Option[String]
-  protected def infPlusSymbol: Option[String]
-  protected def infPlusValue: Option[String]
-  protected val origType: DataType
-
-  def replaceInfinitySymbols(column: Column): Column = {
-    val columnWithNegativeInf: Column = infMinusSymbol.flatMap { minusSymbol =>
-      infMinusValue.map { minusValue =>
-        when(column === lit(minusSymbol).cast(origType), lit(minusValue).cast(origType)).otherwise(column)
-      }
-    }.getOrElse(column)
-
-    infPlusSymbol.flatMap { plusSymbol =>
-      infPlusValue.map { plusValue =>
-        when(columnWithNegativeInf === lit(plusSymbol).cast(origType), lit(plusValue).cast(origType))
-          .otherwise(columnWithNegativeInf)
-      }
-    }.getOrElse(columnWithNegativeInf)
   }
 }
 

--- a/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
@@ -22,14 +22,16 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.slf4j.{Logger, LoggerFactory}
 import za.co.absa.spark.commons.implicits.ColumnImplicits.ColumnEnhancements
+import za.co.absa.spark.commons.implicits.StructFieldImplicits.StructFieldMetadataEnhancements
 import za.co.absa.spark.commons.implicits.StructTypeImplicits.StructTypeEnhancements
 import za.co.absa.spark.commons.utils.SchemaUtils
 import za.co.absa.spark.hofs.transform
 import za.co.absa.standardization.{ErrorMessage, StandardizationErrorMessage}
 import za.co.absa.standardization.config.StandardizationConfig
 import za.co.absa.standardization.implicits.StdColumnImplicits.StdColumnEnhancements
+import za.co.absa.standardization.numeric.DecimalSymbols
 import za.co.absa.standardization.schema.StdSchemaUtils.FieldWithSource
-import za.co.absa.standardization.schema.{MetadataValues, StdSchemaUtils}
+import za.co.absa.standardization.schema.{MetadataKeys, MetadataValues, StdSchemaUtils}
 import za.co.absa.standardization.time.DateTimePattern
 import za.co.absa.standardization.typeClasses.{DoubleLike, LongLike}
 import za.co.absa.standardization.types.TypedStructField._
@@ -127,6 +129,7 @@ object TypeParser {
   private val MicrosecondsPerSecond = 1000000
   private val NanosecondsPerSecond  = 1000000000
   private val InfinityStr = "Infinity"
+  private val MinusInfinityStr = "-Infinity"
   private val nullColumn = lit(null) //scalastyle:ignore null
 
 
@@ -315,7 +318,13 @@ object TypeParser {
   }
 
   private abstract class NumericParser[N: TypeTag](override val field: NumericTypeStructField[N])
-                                                  (implicit defaults: TypeDefaults) extends ScalarParser[N] {
+                                                  (implicit defaults: TypeDefaults) extends ScalarParser[N] with InfinitySupport {
+    override protected val infMinusSymbol: Option[String] = metadata.getOptString(MetadataKeys.MinusInfinitySymbol)
+    override protected val infMinusValue: Option[String] = metadata.getOptString(MetadataKeys.MinusInfinityValue)
+    override protected val infPlusSymbol: Option[String] = metadata.getOptString(MetadataKeys.PlusInfinitySymbol)
+    override protected val infPlusValue: Option[String] = metadata.getOptString(MetadataKeys.PlusInfinityValue)
+    private val columnWithInfinityReplaced = replaceInfinitySymbols(column)
+
     override protected def standardizeAfterCheck(stdConfig: StandardizationConfig)(implicit logger: Logger): ParseOutput = {
       if (field.needsUdfParsing) {
         standardizeUsingUdf(stdConfig)
@@ -335,9 +344,9 @@ object TypeParser {
         val columnWithProperDecimalSymbols: Column = if (replacements.nonEmpty) {
           val from = replacements.keys.mkString
           val to = replacements.values.mkString
-          translate(column, from, to)
+          translate(columnWithInfinityReplaced, from, to)
         } else {
-          column
+          columnWithInfinityReplaced
         }
 
         val columnToCast = if (field.allowInfinity && (decimalSymbols.infinityValue != InfinityStr)) {
@@ -494,9 +503,14 @@ object TypeParser {
     * Date          | O                               | ->to_utc_timestamp->to_date
     * Other         | ->String->to_date               | ->String->to_timestamp->to_utc_timestamp->to_date
     */
-  private abstract class DateTimeParser[T](implicit defaults: TypeDefaults) extends PrimitiveParser[T] {
+  private abstract class DateTimeParser[T](implicit defaults: TypeDefaults) extends PrimitiveParser[T] with InfinitySupport {
     override val field: DateTimeTypeStructField[T]
     protected val pattern: DateTimePattern = field.pattern.get.get
+    override protected val infMinusSymbol: Option[String] = metadata.getOptString(MetadataKeys.MinusInfinitySymbol)
+    override protected val infMinusValue: Option[String] = metadata.getOptString(MetadataKeys.MinusInfinityValue)
+    override protected val infPlusSymbol: Option[String] = metadata.getOptString(MetadataKeys.PlusInfinitySymbol)
+    override protected val infPlusValue: Option[String] = metadata.getOptString(MetadataKeys.PlusInfinityValue)
+    private val columnWithInfinityReplaced: Column = replaceInfinitySymbols(column)
 
     override protected def assemblePrimitiveCastLogic: Column = {
       if (pattern.isEpoch) {
@@ -516,23 +530,23 @@ object TypeParser {
 
     private def castWithPattern(): Column = {
       // sadly with parquet support, incoming might not be all `plain`
-//      underlyingType match {
+      // underlyingType match {
       origType match {
         case _: NullType                  => nullColumn
-        case _: DateType                  => castDateColumn(column)
-        case _: TimestampType             => castTimestampColumn(column)
-        case _: StringType                => castStringColumn(column)
+        case _: DateType                  => castDateColumn(columnWithInfinityReplaced)
+        case _: TimestampType             => castTimestampColumn(columnWithInfinityReplaced)
+        case _: StringType                => castStringColumn(columnWithInfinityReplaced)
         case ot: DoubleType               =>
           // this case covers some IBM date format where it's represented as a double ddmmyyyy.hhmmss
           patternNeeded(ot)
-          castFractionalColumn(column, ot)
+          castFractionalColumn(columnWithInfinityReplaced, ot)
         case ot: FloatType                =>
           // this case covers some IBM date format where it's represented as a double ddmmyyyy.hhmmss
           patternNeeded(ot)
-          castFractionalColumn(column, ot)
+          castFractionalColumn(columnWithInfinityReplaced, ot)
         case ot                           =>
           patternNeeded(ot)
-          castNonStringColumn(column, ot)
+          castNonStringColumn(columnWithInfinityReplaced, ot)
       }
     }
 
@@ -554,7 +568,7 @@ object TypeParser {
     }
 
     protected def castEpoch(): Column = {
-      (column.cast(decimalType) / pattern.epochFactor).cast(TimestampType)
+      (columnWithInfinityReplaced.cast(decimalType) / pattern.epochFactor).cast(TimestampType)
     }
 
     protected def castStringColumn(stringColumn: Column): Column
@@ -678,6 +692,29 @@ object TypeParser {
         timestampColumn
       )
     }
+  }
+}
+
+sealed trait InfinitySupport {
+  protected def infMinusSymbol: Option[String]
+  protected def infMinusValue: Option[String]
+  protected def infPlusSymbol: Option[String]
+  protected def infPlusValue: Option[String]
+  protected val origType: DataType
+
+  def replaceInfinitySymbols(column: Column): Column = {
+    val columnWithNegativeInf: Column = infMinusSymbol.flatMap { minusSymbol =>
+      infMinusValue.map { minusValue =>
+        when(column === lit(minusSymbol).cast(origType), lit(minusValue).cast(origType)).otherwise(column)
+      }
+    }.getOrElse(column)
+
+    infPlusSymbol.flatMap { plusSymbol =>
+      infPlusValue.map { plusValue =>
+        when(columnWithNegativeInf === lit(plusSymbol).cast(origType), lit(plusValue).cast(origType))
+          .otherwise(columnWithNegativeInf)
+      }
+    }.getOrElse(columnWithNegativeInf)
   }
 }
 

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
@@ -18,14 +18,13 @@ package za.co.absa.standardization.interpreter
 
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
-import za.co.absa.standardization.ErrorMessage
+import za.co.absa.standardization.{ErrorMessage, LoggerTestBase, Standardization, StandardizationErrorMessage, interpreter}
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
 import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
 import za.co.absa.standardization.schema.MetadataKeys
 import za.co.absa.standardization.types.{CommonTypeDefaults, TypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
-import za.co.absa.standardization.{LoggerTestBase, Standardization, StandardizationErrorMessage}
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 
 class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkTestBase with LoggerTestBase {
@@ -82,8 +81,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
         + "789123456789123456789123456791245678912324789123456789123456789123456789123456789123456791245678912324789123"
         + "456789123456789123456789123456789123456789123456789123456789.1"),
       ("06-Text", "foo", "bar"),
-      ("07-Exponential notation", "-1.23E4", "+9.8765E-3"),
-      ("08-Infinity", "FRRR", "MAXVALUE")
+      ("07-Exponential notation", "-1.23E4", "+9.8765E-3")
     )
     val src = seq.toDF("description","floatField", "doubleField")
     logDataFrameContent(src)
@@ -110,7 +108,6 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
         StandardizationErrorMessage.stdCastErr("floatField", "foo", "string", "float", None),
         StandardizationErrorMessage.stdCastErr("doubleField", "bar", "string", "double", None))),
       FractionalRow("07-Exponential notation", Option(-12300.0f), Option(0.0098765)),
-      FractionalRow("08-Infinity", Option(0f), Option(Double.PositiveInfinity))
     )
 
     assertResult(exp)(std.as[FractionalRow].collect().sortBy(_.description).toList)
@@ -185,7 +182,8 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
         + "678912345678912345678912345679124567891232478912345678912345678912345678912345678912345679124567891232478912"
         + "3456789123456789123456789123456789123456789123456789123456789.1"),
       ("06-Text", "foo", "bar"),
-      ("07-Exponential notation", "-1.23E4", "+9.8765E-3")
+      ("07-Exponential notation", "-1.23E4", "+9.8765E-3"),
+      ("08-Infinity", "FRRR", "MAXVALUE")
     )
     val src = seq.toDF("description","floatField", "doubleField")
     logDataFrameContent(src)
@@ -203,7 +201,8 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
       FractionalRow("06-Text", Option(0), None, Seq(
         StandardizationErrorMessage.stdCastErr("floatField", "foo", "string", "float", None),
         StandardizationErrorMessage.stdCastErr("doubleField", "bar", "string", "double", None))),
-      FractionalRow("07-Exponential notation", Option(-12300.0f), Option(0.0098765))
+      FractionalRow("07-Exponential notation", Option(-12300.0f), Option(0.0098765)),
+      FractionalRow("08-Infinity", Option(0f), Option(Double.PositiveInfinity))
     )
 
     assertResult(exp)(std.as[FractionalRow].collect().sortBy(_.description).toList)

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
@@ -107,7 +107,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
       FractionalRow("06-Text", Option(0), None, Seq(
         StandardizationErrorMessage.stdCastErr("floatField", "foo", "string", "float", None),
         StandardizationErrorMessage.stdCastErr("doubleField", "bar", "string", "double", None))),
-      FractionalRow("07-Exponential notation", Option(-12300.0f), Option(0.0098765)),
+      FractionalRow("07-Exponential notation", Option(-12300.0f), Option(0.0098765))
     )
 
     assertResult(exp)(std.as[FractionalRow].collect().sortBy(_.description).toList)

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
@@ -57,9 +57,17 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
   private val desiredSchemaWithInfinity = StructType(Seq(
     StructField("description", StringType, nullable = false),
     StructField("floatField", FloatType, nullable = false,
-      new MetadataBuilder().putString("allow_infinity", value = "true").build),
+      new MetadataBuilder()
+        .putString("allow_infinity", value = "true")
+        .putString(MetadataKeys.MinusInfinitySymbol, "FRRR")
+        .putString(MetadataKeys.MinusInfinityValue, "0")
+        .build),
     StructField("doubleField", DoubleType, nullable = true,
-      new MetadataBuilder().putString("allow_infinity", value = "true").build)
+      new MetadataBuilder()
+        .putString("allow_infinity", value = "true")
+        .putString(MetadataKeys.PlusInfinitySymbol, "MAXVALUE")
+        .putString(MetadataKeys.PlusInfinityValue, "∞")
+        .build)
   ))
 
   test("From String") {
@@ -74,7 +82,8 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
         + "789123456789123456789123456791245678912324789123456789123456789123456789123456789123456791245678912324789123"
         + "456789123456789123456789123456789123456789123456789123456789.1"),
       ("06-Text", "foo", "bar"),
-      ("07-Exponential notation", "-1.23E4", "+9.8765E-3")
+      ("07-Exponential notation", "-1.23E4", "+9.8765E-3"),
+      ("08-Infinity", "FRRR", "MAXVALUE")
     )
     val src = seq.toDF("description","floatField", "doubleField")
     logDataFrameContent(src)
@@ -100,7 +109,8 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
       FractionalRow("06-Text", Option(0), None, Seq(
         StandardizationErrorMessage.stdCastErr("floatField", "foo", "string", "float", None),
         StandardizationErrorMessage.stdCastErr("doubleField", "bar", "string", "double", None))),
-      FractionalRow("07-Exponential notation", Option(-12300.0f), Option(0.0098765))
+      FractionalRow("07-Exponential notation", Option(-12300.0f), Option(0.0098765)),
+      FractionalRow("08-Infinity", Option(0f), Option(Double.PositiveInfinity))
     )
 
     assertResult(exp)(std.as[FractionalRow].collect().sortBy(_.description).toList)
@@ -168,7 +178,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
       ("01-Euler", "2.71", "2.71"),
       ("02-Null", null, null),
       ("03-Long", Long.MaxValue.toString, Long.MinValue.toString),
-      ("04-infinity", "-∞", "∞"),
+      ("04-infinity", "-∞", "MAXVALUE"),
       ("05-Really big", "123456789123456791245678912324789123456789123456789.12",
         "-1234567891234567912456789123247891234567891234567891234567891234567891234567891234567891234567891234567891234"
         + "567891234567891234567891234567891234567891234567891234567891234567891234567891234567891234567891234678912345"

--- a/src/test/scala/za/co/absa/standardization/interpreter/stages/TypeParser_FromBooleanTypeSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/stages/TypeParser_FromBooleanTypeSuite.scala
@@ -17,7 +17,9 @@
 package za.co.absa.standardization.interpreter.stages
 
 import org.apache.spark.sql.types._
+import za.co.absa.spark.commons.implicits.StructFieldImplicits.StructFieldMetadataEnhancements
 import za.co.absa.standardization.interpreter.stages.TypeParserSuiteTemplate.Input
+import za.co.absa.standardization.schema.MetadataKeys
 import za.co.absa.standardization.time.DateTimePattern
 
 class TypeParser_FromBooleanTypeSuite extends TypeParserSuiteTemplate  {
@@ -32,16 +34,30 @@ class TypeParser_FromBooleanTypeSuite extends TypeParserSuiteTemplate  {
     path = "Boo"
   )
 
-  override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
+  override protected def createCastTemplate(srcStructField: StructField, target: StructField, pattern: String, timezone: Option[String]): String = {
+    val (infMinusValue, infMinusSymbol, infPlusValue, infPlusSymbol): (Option[String], Option[String], Option[String], Option[String]) = {
+      val infMinusValue = target.metadata.getOptString(MetadataKeys.MinusInfinityValue)
+      val infMinusSymbol = target.metadata.getOptString(MetadataKeys.MinusInfinitySymbol)
+      val infPlusValue = target.metadata.getOptString(MetadataKeys.PlusInfinityValue)
+      val infPlusSymbol = target.metadata.getOptString(MetadataKeys.PlusInfinitySymbol)
+      (infMinusValue, infMinusSymbol, infPlusValue, infPlusSymbol)
+    }
+    val srcType = srcStructField.dataType.sql
+
     val isEpoch = DateTimePattern.isEpoch(pattern)
-    (toType, isEpoch, timezone) match {
+    (target.dataType, isEpoch, timezone) match {
       case (DateType, true, _)                      => s"to_date(CAST((CAST(`%s` AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}L) AS TIMESTAMP))"
       case (TimestampType, true, _)                 => s"CAST((CAST(%s AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}) AS TIMESTAMP)"
       case (DateType, _, Some(tz))                  => s"to_date(to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), '$tz'))"
       case (TimestampType, _, Some(tz))             => s"to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), $tz)"
       case (TimestampType, _, _)                    => s"to_timestamp(CAST(`%s` AS STRING), '$pattern')"
       case (DateType, _, _)                         => s"to_date(CAST(`%s` AS STRING), '$pattern')"
-      case _                                        => s"CAST(%s AS ${toType.sql})"
+      case (ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType | _: DecimalType, _, _) if (infMinusValue.isDefined && infMinusSymbol.isDefined && infPlusValue.isDefined && infPlusSymbol.isDefined) =>
+        s"CAST(CASE WHEN (CASE WHEN (%s = ${infMinusSymbol.get}) THEN CAST(${infMinusValue.get} AS $srcType) " +
+          s"ELSE %s END = ${infPlusSymbol.get}) THEN CAST(${infPlusValue.get} AS $srcType) ELSE CASE WHEN " +
+          s"(%s = ${infMinusSymbol.get}) THEN CAST(${infMinusValue.get} AS $srcType) ELSE %s END END " +
+          s"AS ${target.dataType.sql})"
+      case _                                        => s"CAST(%s AS ${target.dataType.sql})"
     }
   }
 

--- a/src/test/scala/za/co/absa/standardization/interpreter/stages/TypeParser_FromDateTypeSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/stages/TypeParser_FromDateTypeSuite.scala
@@ -17,7 +17,9 @@
 package za.co.absa.standardization.interpreter.stages
 
 import org.apache.spark.sql.types._
+import za.co.absa.spark.commons.implicits.StructFieldImplicits.StructFieldMetadataEnhancements
 import za.co.absa.standardization.interpreter.stages.TypeParserSuiteTemplate.Input
+import za.co.absa.standardization.schema.MetadataKeys
 import za.co.absa.standardization.time.DateTimePattern
 
 class TypeParser_FromDateTypeSuite extends TypeParserSuiteTemplate  {
@@ -33,16 +35,30 @@ class TypeParser_FromDateTypeSuite extends TypeParserSuiteTemplate  {
     datetimeNeedsPattern = false
   )
 
-  override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
+  override protected def createCastTemplate(srcStructField: StructField, target: StructField, pattern: String, timezone: Option[String]): String = {
+    val (infMinusValue, infMinusSymbol, infPlusValue, infPlusSymbol): (Option[String], Option[String], Option[String], Option[String]) = {
+      val infMinusValue = target.metadata.getOptString(MetadataKeys.MinusInfinityValue)
+      val infMinusSymbol = target.metadata.getOptString(MetadataKeys.MinusInfinitySymbol)
+      val infPlusValue = target.metadata.getOptString(MetadataKeys.PlusInfinityValue)
+      val infPlusSymbol = target.metadata.getOptString(MetadataKeys.PlusInfinitySymbol)
+      (infMinusValue, infMinusSymbol, infPlusValue, infPlusSymbol)
+    }
+    val srcType = srcStructField.dataType.sql
+
     val isEpoch = DateTimePattern.isEpoch(pattern)
-    (toType, isEpoch, timezone) match {
+    (target.dataType, isEpoch, timezone) match {
       case (DateType, true, _)               => s"to_date(CAST((CAST(`%s` AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}L) AS TIMESTAMP))"
       case (TimestampType, true, _)          => s"CAST((CAST(%s AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}) AS TIMESTAMP)"
       case (DateType, _, Some(tz))           => s"to_date(to_utc_timestamp(`%s`, '$tz'))"
       case (TimestampType, _, Some(tz))      => s"to_utc_timestamp(%s, $tz)"
       case (DateType, _, _)                  => "%s"
       case (TimestampType, _, _)             => "to_timestamp(`%s`)"
-      case _                                 => s"CAST(%s AS ${toType.sql})"
+      case (ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType | _: DecimalType, _, _) if (infMinusValue.isDefined && infMinusSymbol.isDefined && infPlusValue.isDefined && infPlusSymbol.isDefined) =>
+        s"CAST(CASE WHEN (CASE WHEN (%s = ${infMinusSymbol.get}) THEN CAST(${infMinusValue.get} AS $srcType) " +
+          s"ELSE %s END = ${infPlusSymbol.get}) THEN CAST(${infPlusValue.get} AS $srcType) ELSE CASE WHEN " +
+          s"(%s = ${infMinusSymbol.get}) THEN CAST(${infMinusValue.get} AS $srcType) ELSE %s END END " +
+          s"AS ${target.dataType.sql})"
+      case _                                 => s"CAST(%s AS ${target.dataType.sql})"
     }
   }
 

--- a/src/test/scala/za/co/absa/standardization/interpreter/stages/TypeParser_FromDecimalTypeSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/stages/TypeParser_FromDecimalTypeSuite.scala
@@ -17,7 +17,9 @@
 package za.co.absa.standardization.interpreter.stages
 
 import org.apache.spark.sql.types._
+import za.co.absa.spark.commons.implicits.StructFieldImplicits.StructFieldMetadataEnhancements
 import za.co.absa.standardization.interpreter.stages.TypeParserSuiteTemplate.Input
+import za.co.absa.standardization.schema.MetadataKeys
 import za.co.absa.standardization.time.DateTimePattern
 
 class TypeParser_FromDecimalTypeSuite extends TypeParserSuiteTemplate  {
@@ -32,16 +34,30 @@ class TypeParser_FromDecimalTypeSuite extends TypeParserSuiteTemplate  {
     path = "hello"
   )
 
-  override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
+  override protected def createCastTemplate(srcStructField: StructField, target: StructField, pattern: String, timezone: Option[String]): String = {
+    val (infMinusValue, infMinusSymbol, infPlusValue, infPlusSymbol): (Option[String], Option[String], Option[String], Option[String]) = {
+      val infMinusValue = target.metadata.getOptString(MetadataKeys.MinusInfinityValue)
+      val infMinusSymbol = target.metadata.getOptString(MetadataKeys.MinusInfinitySymbol)
+      val infPlusValue = target.metadata.getOptString(MetadataKeys.PlusInfinityValue)
+      val infPlusSymbol = target.metadata.getOptString(MetadataKeys.PlusInfinitySymbol)
+      (infMinusValue, infMinusSymbol, infPlusValue, infPlusSymbol)
+    }
+    val srcType = srcStructField.dataType.sql
+
     val isEpoch = DateTimePattern.isEpoch(pattern)
-    (toType, isEpoch, timezone) match {
+    (target.dataType, isEpoch, timezone) match {
       case (DateType, true, _)                      => s"to_date(CAST((CAST(`%s` AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}L) AS TIMESTAMP))"
       case (TimestampType, true, _)                 => s"CAST((CAST(%s AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}) AS TIMESTAMP)"
       case (DateType, _, Some(tz))                  => s"to_date(to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), '$tz'))"
       case (TimestampType, _, Some(tz))             => s"to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), $tz)"
       case (TimestampType, _, _)                    => s"to_timestamp(CAST(`%s` AS STRING), '$pattern')"
       case (DateType, _, _)                         => s"to_date(CAST(`%s` AS STRING), '$pattern')"
-      case _                                        => s"CAST(%s AS ${toType.sql})"
+      case (ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType | _: DecimalType, _, _) if (infMinusValue.isDefined && infMinusSymbol.isDefined && infPlusValue.isDefined && infPlusSymbol.isDefined) =>
+        s"CAST(CASE WHEN (CASE WHEN (%s = ${infMinusSymbol.get}) THEN CAST(${infMinusValue.get} AS $srcType) " +
+          s"ELSE %s END = ${infPlusSymbol.get}) THEN CAST(${infPlusValue.get} AS $srcType) ELSE CASE WHEN " +
+          s"(%s = ${infMinusSymbol.get}) THEN CAST(${infMinusValue.get} AS $srcType) ELSE %s END END " +
+          s"AS ${target.dataType.sql})"
+      case _                                        => s"CAST(%s AS ${target.dataType.sql})"
     }
   }
 

--- a/src/test/scala/za/co/absa/standardization/interpreter/stages/TypeParser_FromLongTypeSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/stages/TypeParser_FromLongTypeSuite.scala
@@ -17,7 +17,9 @@
 package za.co.absa.standardization.interpreter.stages
 
 import org.apache.spark.sql.types._
+import za.co.absa.spark.commons.implicits.StructFieldImplicits.StructFieldMetadataEnhancements
 import za.co.absa.standardization.interpreter.stages.TypeParserSuiteTemplate.Input
+import za.co.absa.standardization.schema.MetadataKeys
 import za.co.absa.standardization.time.DateTimePattern
 
 class TypeParser_FromLongTypeSuite extends TypeParserSuiteTemplate {
@@ -32,16 +34,30 @@ class TypeParser_FromLongTypeSuite extends TypeParserSuiteTemplate {
     path = "Hey"
   )
 
-  override protected def createCastTemplate(toType: DataType, pattern: String, timezone: Option[String]): String = {
+  override protected def createCastTemplate(srcStructField: StructField, target: StructField, pattern: String, timezone: Option[String]): String = {
+    val (infMinusValue, infMinusSymbol, infPlusValue, infPlusSymbol): (Option[String], Option[String], Option[String], Option[String]) = {
+      val infMinusValue = target.metadata.getOptString(MetadataKeys.MinusInfinityValue)
+      val infMinusSymbol = target.metadata.getOptString(MetadataKeys.MinusInfinitySymbol)
+      val infPlusValue = target.metadata.getOptString(MetadataKeys.PlusInfinityValue)
+      val infPlusSymbol = target.metadata.getOptString(MetadataKeys.PlusInfinitySymbol)
+      (infMinusValue, infMinusSymbol, infPlusValue, infPlusSymbol)
+    }
+    val srcType = srcStructField.dataType.sql
+
     val isEpoch = DateTimePattern.isEpoch(pattern)
-    (toType, isEpoch, timezone) match {
+    (target.dataType, isEpoch, timezone) match {
       case (DateType, true, _)                      => s"to_date(CAST((CAST(`%s` AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}L) AS TIMESTAMP))"
       case (TimestampType, true, _)                 => s"CAST((CAST(%s AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}) AS TIMESTAMP)"
       case (DateType, _, Some(tz))                  => s"to_date(to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), '$tz'))"
       case (TimestampType, _, Some(tz))             => s"to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), $tz)"
       case (TimestampType, _, _)                    => s"to_timestamp(CAST(`%s` AS STRING), '$pattern')"
       case (DateType, _, _)                         => s"to_date(CAST(`%s` AS STRING), '$pattern')"
-      case _                                        => s"CAST(%s AS ${toType.sql})"
+      case (ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType | _: DecimalType, _, _) if (infMinusValue.isDefined && infMinusSymbol.isDefined && infPlusValue.isDefined && infPlusSymbol.isDefined) =>
+        s"CAST(CASE WHEN (CASE WHEN (%s = ${infMinusSymbol.get}) THEN CAST(${infMinusValue.get} AS $srcType) " +
+          s"ELSE %s END = ${infPlusSymbol.get}) THEN CAST(${infPlusValue.get} AS $srcType) ELSE CASE WHEN " +
+          s"(%s = ${infMinusSymbol.get}) THEN CAST(${infMinusValue.get} AS $srcType) ELSE %s END END " +
+          s"AS ${target.dataType.sql})"
+      case _                                        => s"CAST(%s AS ${target.dataType.sql})"
     }
   }
 
@@ -49,7 +65,7 @@ class TypeParser_FromLongTypeSuite extends TypeParserSuiteTemplate {
     target.dataType match {
       case FloatType | DoubleType => s"(($castS IS NULL) OR isnan($castS)) OR ($castS IN (Infinity, -Infinity))"
       case ByteType | ShortType | IntegerType =>
-        s"($castS IS NULL) OR (NOT (CAST(Hey.sourceField AS INT) = CAST(Hey.sourceField AS BIGINT)))"
+        s"($castS IS NULL) OR (NOT ($castS = CAST(Hey.sourceField AS BIGINT)))"
       case _ => s"$castS IS NULL"
     }
   }


### PR DESCRIPTION
Closes #61 

Adds support or infinity replacements on Dates, Timestamps and Numeric fields. 

It works before the "spark built-in" infinity replacements that use `∞` and has no dependency on `allowInfinity` metadata field. 

New metadata fields are now supported are:
- minus_infinity_symbol
- minus_infinity_value
- plus_infinity_symbol
- plus_infinity_value