### PR TITLE
#64 support mainframe century

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Zejnilovic @dk1844 @benedeki @lsulak
+* @Zejnilovic @dk1844 @benedeki @lsulak @yruslan

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,6 @@ on:
     branches: [ main, develop, master ]
   pull_request:
     branches: [ master, develop ]
-    types: [ assigned, opened, synchronize, reopened, labeled ]
 
 jobs:
   test:

--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -19,7 +19,6 @@ name: FormatCheck
 on:
   pull_request:
     branches: [ master, develop ]
-    types: [ assigned, opened, synchronize, reopened, labeled ]
 
 jobs:
   scalafmt:

--- a/.github/workflows/jacoco_check.yml
+++ b/.github/workflows/jacoco_check.yml
@@ -19,7 +19,6 @@ name: JaCoCo report
 on:
   pull_request:
     branches: [ master ]
-    types: [ opened, edited, synchronize, reopened ]
 
 jobs:
   test:

--- a/.github/workflows/licence_check.yml
+++ b/.github/workflows/licence_check.yml
@@ -21,7 +21,6 @@ on:
     branches: [ main, develop, master ]
   pull_request:
     branches: [ master ]
-    types: [ assigned, opened, synchronize, reopened, labeled ]
 
 jobs:
   license-test:

--- a/src/main/scala/za/co/absa/standardization/schema/MetadataKeys.scala
+++ b/src/main/scala/za/co/absa/standardization/schema/MetadataKeys.scala
@@ -26,6 +26,7 @@ object MetadataKeys {
   val MinusInfinityValue = "minus_infinity_value"
   val PlusInfinitySymbol = "plus_infinity_symbol"
   val PlusInfinityValue = "plus_infinity_value"
+  val IsCenturyPatter = "is_century_pattern"
   // date & timestamp & all numeric
   val Pattern = "pattern"
   // all numeric

--- a/src/main/scala/za/co/absa/standardization/schema/MetadataKeys.scala
+++ b/src/main/scala/za/co/absa/standardization/schema/MetadataKeys.scala
@@ -26,7 +26,6 @@ object MetadataKeys {
   val MinusInfinityValue = "minus_infinity_value"
   val PlusInfinitySymbol = "plus_infinity_symbol"
   val PlusInfinityValue = "plus_infinity_value"
-  val IsCenturyPatter = "is_century_pattern"
   // date & timestamp & all numeric
   val Pattern = "pattern"
   // all numeric
@@ -41,6 +40,8 @@ object MetadataKeys {
   val Encoding = "encoding"
   //decimal
   val StrictParsing = "strict_parsing"
+  // For nonstandard data inputs like the Mainframe's century pattern
+  val IsNonStandard = "is_non_standard"
 }
 
 object MetadataValues {

--- a/src/main/scala/za/co/absa/standardization/stages/InfinitySupport.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/InfinitySupport.scala
@@ -22,13 +22,9 @@ import org.apache.spark.sql.types.DataType
 
 trait InfinitySupport {
   protected def infMinusSymbol: Option[String]
-
   protected def infMinusValue: Option[String]
-
   protected def infPlusSymbol: Option[String]
-
   protected def infPlusValue: Option[String]
-
   protected val origType: DataType
 
   def replaceInfinitySymbols(column: Column): Column = {

--- a/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
@@ -617,7 +617,7 @@ object TypeParser {
 
     override protected def castStringColumn(stringColumn: Column): Column = {
       val columWithCenturyReplaced: Column =
-        if (pattern.isCentury && metadata.getOptStringAsBoolean(MetadataKeys.IsCenturyPatter).getOrElse(false)) {
+        if (pattern.isCentury && metadata.getOptStringAsBoolean(MetadataKeys.IsNonStandard).getOrElse(false)) {
           replaceCenturyUDF(stringColumn, lit(pattern.originalPattern.get))
         } else { stringColumn }
 
@@ -669,7 +669,7 @@ object TypeParser {
 
     override protected def castStringColumn(stringColumn: Column): Column = {
       val columWithCenturyReplaced: Column =
-        if (pattern.isCentury && metadata.getOptStringAsBoolean(MetadataKeys.IsCenturyPatter).getOrElse(false)) {
+        if (pattern.isCentury && metadata.getOptStringAsBoolean(MetadataKeys.IsNonStandard).getOrElse(false)) {
         replaceCenturyUDF(stringColumn, lit(pattern.originalPattern.get))
       } else { stringColumn }
 

--- a/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
@@ -29,7 +29,6 @@ import za.co.absa.spark.hofs.transform
 import za.co.absa.standardization.{ErrorMessage, StandardizationErrorMessage}
 import za.co.absa.standardization.config.StandardizationConfig
 import za.co.absa.standardization.implicits.StdColumnImplicits.StdColumnEnhancements
-import za.co.absa.standardization.numeric.DecimalSymbols
 import za.co.absa.standardization.schema.StdSchemaUtils.FieldWithSource
 import za.co.absa.standardization.schema.{MetadataKeys, MetadataValues, StdSchemaUtils}
 import za.co.absa.standardization.time.DateTimePattern
@@ -692,29 +691,6 @@ object TypeParser {
         timestampColumn
       )
     }
-  }
-}
-
-sealed trait InfinitySupport {
-  protected def infMinusSymbol: Option[String]
-  protected def infMinusValue: Option[String]
-  protected def infPlusSymbol: Option[String]
-  protected def infPlusValue: Option[String]
-  protected val origType: DataType
-
-  def replaceInfinitySymbols(column: Column): Column = {
-    val columnWithNegativeInf: Column = infMinusSymbol.flatMap { minusSymbol =>
-      infMinusValue.map { minusValue =>
-        when(column === lit(minusSymbol).cast(origType), lit(minusValue).cast(origType)).otherwise(column)
-      }
-    }.getOrElse(column)
-
-    infPlusSymbol.flatMap { plusSymbol =>
-      infPlusValue.map { plusValue =>
-        when(columnWithNegativeInf === lit(plusSymbol).cast(origType), lit(plusValue).cast(origType))
-          .otherwise(columnWithNegativeInf)
-      }
-    }.getOrElse(columnWithNegativeInf)
   }
 }
 

--- a/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
@@ -29,6 +29,7 @@ import za.co.absa.spark.hofs.transform
 import za.co.absa.standardization.{ErrorMessage, StandardizationErrorMessage}
 import za.co.absa.standardization.config.StandardizationConfig
 import za.co.absa.standardization.implicits.StdColumnImplicits.StdColumnEnhancements
+import za.co.absa.standardization.numeric.DecimalSymbols
 import za.co.absa.standardization.schema.StdSchemaUtils.FieldWithSource
 import za.co.absa.standardization.schema.{MetadataKeys, MetadataValues, StdSchemaUtils}
 import za.co.absa.standardization.time.DateTimePattern
@@ -691,6 +692,29 @@ object TypeParser {
         timestampColumn
       )
     }
+  }
+}
+
+sealed trait InfinitySupport {
+  protected def infMinusSymbol: Option[String]
+  protected def infMinusValue: Option[String]
+  protected def infPlusSymbol: Option[String]
+  protected def infPlusValue: Option[String]
+  protected val origType: DataType
+
+  def replaceInfinitySymbols(column: Column): Column = {
+    val columnWithNegativeInf: Column = infMinusSymbol.flatMap { minusSymbol =>
+      infMinusValue.map { minusValue =>
+        when(column === lit(minusSymbol).cast(origType), lit(minusValue).cast(origType)).otherwise(column)
+      }
+    }.getOrElse(column)
+
+    infPlusSymbol.flatMap { plusSymbol =>
+      infPlusValue.map { plusValue =>
+        when(columnWithNegativeInf === lit(plusSymbol).cast(origType), lit(plusValue).cast(origType))
+          .otherwise(columnWithNegativeInf)
+      }
+    }.getOrElse(columnWithNegativeInf)
   }
 }
 

--- a/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
@@ -616,9 +616,10 @@ object TypeParser {
     }
 
     override protected def castStringColumn(stringColumn: Column): Column = {
-      val columWithCenturyReplaced: Column = if (pattern.isCentury) {
-        replaceCenturyUDF(stringColumn, lit(pattern.originalPattern.get))
-      } else { stringColumn }
+      val columWithCenturyReplaced: Column =
+        if (pattern.isCentury && metadata.getOptStringAsBoolean(MetadataKeys.IsCenturyPatter).getOrElse(false)) {
+          replaceCenturyUDF(stringColumn, lit(pattern.originalPattern.get))
+        } else { stringColumn }
 
       if (pattern.containsSecondFractions) {
         // date doesn't need to care about second fractions
@@ -667,7 +668,8 @@ object TypeParser {
     }
 
     override protected def castStringColumn(stringColumn: Column): Column = {
-      val columWithCenturyReplaced: Column = if (pattern.isCentury) {
+      val columWithCenturyReplaced: Column =
+        if (pattern.isCentury && metadata.getOptStringAsBoolean(MetadataKeys.IsCenturyPatter).getOrElse(false)) {
         replaceCenturyUDF(stringColumn, lit(pattern.originalPattern.get))
       } else { stringColumn }
 

--- a/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
@@ -34,6 +34,7 @@ import za.co.absa.standardization.schema.{MetadataKeys, MetadataValues, StdSchem
 import za.co.absa.standardization.time.DateTimePattern
 import za.co.absa.standardization.typeClasses.{DoubleLike, LongLike}
 import za.co.absa.standardization.types.TypedStructField._
+import za.co.absa.standardization.types.parsers.DateTimeParser
 import za.co.absa.standardization.types.{ParseOutput, TypeDefaults, TypedStructField}
 import za.co.absa.standardization.udf.{UDFBuilder, UDFNames}
 
@@ -511,6 +512,17 @@ object TypeParser {
     override protected val infPlusValue: Option[String] = metadata.getOptString(MetadataKeys.PlusInfinityValue)
     private val columnWithInfinityReplaced: Column = replaceInfinitySymbols(column)
 
+    protected val replaceCenturyUDF: UserDefinedFunction = udf((inputDate: String, centuryPattern: String) => {
+      val centuryIndex = centuryPattern.indexOf(DateTimePattern.patternCenturyChar)
+      val padding = centuryPattern.length - inputDate.length
+      val leftPadding = "0" * padding
+      val pendedInput = leftPadding + inputDate
+
+      val charAtPos = pendedInput.charAt(centuryIndex).asDigit
+      val modifiedChar = (charAtPos + 19).toString // Add 19 and convert back to string
+      pendedInput.substring(0, centuryIndex) + modifiedChar + pendedInput.substring(centuryIndex + 1)
+    })
+
     override protected def assemblePrimitiveCastLogic: Column = {
       if (pattern.isEpoch) {
         castEpoch()
@@ -604,14 +616,18 @@ object TypeParser {
     }
 
     override protected def castStringColumn(stringColumn: Column): Column = {
+      val columWithCenturyReplaced: Column = if (pattern.isCentury) {
+        replaceCenturyUDF(stringColumn, lit(pattern.originalPattern.get))
+      } else { stringColumn }
+
       if (pattern.containsSecondFractions) {
         // date doesn't need to care about second fractions
         applyPatternToStringColumn(
-          stringColumn.removeSections(
+          columWithCenturyReplaced.removeSections(
             Seq(pattern.millisecondsPosition, pattern.microsecondsPosition, pattern.nanosecondsPosition).flatten
           ), pattern.patternWithoutSecondFractions)
       } else {
-        applyPatternToStringColumn(stringColumn, pattern)
+        applyPatternToStringColumn(columWithCenturyReplaced, pattern)
       }
     }
 
@@ -651,28 +667,32 @@ object TypeParser {
     }
 
     override protected def castStringColumn(stringColumn: Column): Column = {
+      val columWithCenturyReplaced: Column = if (pattern.isCentury) {
+        replaceCenturyUDF(stringColumn, lit(pattern.originalPattern.get))
+      } else { stringColumn }
+
       if (pattern.containsSecondFractions) {
         //this is a trick how to enforce fractions of seconds into the timestamp
         // - turn into timestamp up to seconds precision and that into unix_timestamp,
         // - the second fractions turn into numeric fractions
         // - add both together and convert to timestamp
         val colSeconds = unix_timestamp(applyPatternToStringColumn(
-          stringColumn.removeSections(
+          columWithCenturyReplaced.removeSections(
             Seq(pattern.millisecondsPosition, pattern.microsecondsPosition, pattern.nanosecondsPosition).flatten
           ), pattern.patternWithoutSecondFractions))
 
         val colMilliseconds: Option[Column] =
-          pattern.millisecondsPosition.map(stringColumn.zeroBasedSubstr(_).cast(decimalType) / MillisecondsPerSecond)
+          pattern.millisecondsPosition.map(columWithCenturyReplaced.zeroBasedSubstr(_).cast(decimalType) / MillisecondsPerSecond)
         val colMicroseconds: Option[Column] =
-          pattern.microsecondsPosition.map(stringColumn.zeroBasedSubstr(_).cast(decimalType) / MicrosecondsPerSecond)
+          pattern.microsecondsPosition.map(columWithCenturyReplaced.zeroBasedSubstr(_).cast(decimalType) / MicrosecondsPerSecond)
         val colNanoseconds: Option[Column] =
-          pattern.nanosecondsPosition.map(stringColumn.zeroBasedSubstr(_).cast(decimalType) / NanosecondsPerSecond)
+          pattern.nanosecondsPosition.map(columWithCenturyReplaced.zeroBasedSubstr(_).cast(decimalType) / NanosecondsPerSecond)
         val colFractions: Column =
           (colMilliseconds ++ colMicroseconds ++ colNanoseconds).reduceOption(_ + _).getOrElse(lit(0))
 
         (colSeconds + colFractions).cast(TimestampType)
       } else {
-        applyPatternToStringColumn(stringColumn, pattern)
+        applyPatternToStringColumn(columWithCenturyReplaced, pattern)
       }
     }
 

--- a/src/main/scala/za/co/absa/standardization/time/DateTimePattern.scala
+++ b/src/main/scala/za/co/absa/standardization/time/DateTimePattern.scala
@@ -167,38 +167,6 @@ object DateTimePattern {
     override val isCentury: Boolean = true
   }
 
-//  private final case class StandardDTPattern(override val pattern: String,
-//                                             assignedDefaultTimeZone: Option[String] = None,
-//                                             override val isDefault: Boolean = false)
-//    extends DateTimePattern(pattern, isDefault) {
-//
-//    override val isEpoch: Boolean = false
-//    override val epochFactor: Long = 0
-//
-//    override val timeZoneInPattern: Boolean = DateTimePattern.timeZoneInPattern(pattern)
-//    override val defaultTimeZone: Option[String] = assignedDefaultTimeZone.filterNot(_ => timeZoneInPattern)
-//    override val isTimeZoned: Boolean = timeZoneInPattern || defaultTimeZone.nonEmpty
-//
-//    val (millisecondsPosition, microsecondsPosition, nanosecondsPosition) = analyzeSecondFractionsPositions(pattern)
-//    override val secondFractionsSections: Seq[Section] = Section.mergeTouchingSectionsAndSort(Seq(millisecondsPosition, microsecondsPosition, nanosecondsPosition).flatten)
-//    override val patternWithoutSecondFractions: String = Section.removeMultipleFrom(pattern, secondFractionsSections)
-//
-//    private def scanForPlaceholder(withinString: String, placeHolder: Char): Option[Section] = {
-//      val start = withinString.findFirstUnquoted(Set(placeHolder), Set('\''))
-//      start.map(index => Section.ofSameChars(withinString, index))
-//    }
-//
-//    private def analyzeSecondFractionsPositions(withinString: String): (Option[Section], Option[Section], Option[Section]) = {
-//      val clearedPattern = withinString
-//
-//      // TODO as part of #7 fix (originally Enceladus#677)
-//      val milliSP = scanForPlaceholder(clearedPattern, patternMilliSecondChar)
-//      val microSP = scanForPlaceholder(clearedPattern, patternMicroSecondChar)
-//      val nanoSP = scanForPlaceholder(clearedPattern, patternNanoSecondChat)
-//      (milliSP, microSP, nanoSP)
-//    }
-//  }
-
   private def create(pattern: String, assignedDefaultTimeZone: Option[String], isDefault: Boolean): DateTimePattern = {
     if (isEpoch(pattern)) {
       EpochDTPattern(pattern, isDefault)

--- a/src/main/scala/za/co/absa/standardization/time/DateTimePattern.scala
+++ b/src/main/scala/za/co/absa/standardization/time/DateTimePattern.scala
@@ -118,8 +118,8 @@ object DateTimePattern {
   }
 
   private abstract class StandardDTPatternBase(override val pattern: String,
-                                                      assignedDefaultTimeZone: Option[String],
-                                                      override val isDefault: Boolean = false)
+                                               assignedDefaultTimeZone: Option[String],
+                                               override val isDefault: Boolean = false)
     extends DateTimePattern(pattern, isDefault) {
 
     override val isEpoch: Boolean = false
@@ -167,10 +167,13 @@ object DateTimePattern {
     override val isCentury: Boolean = true
   }
 
-  private def create(pattern: String, assignedDefaultTimeZone: Option[String], isDefault: Boolean): DateTimePattern = {
+  private def create(pattern: String,
+                     assignedDefaultTimeZone: Option[String],
+                     isCenturyPattern: Boolean,
+                     isDefault: Boolean): DateTimePattern = {
     if (isEpoch(pattern)) {
       EpochDTPattern(pattern, isDefault)
-    } else if (isCentury(pattern)) {
+    } else if (isCenturyPattern && isCentury(pattern)) {
       val patternWithoutCentury = pattern.replaceAll(patternCenturyChar, "yy")
       CenturyDTPattern(patternWithoutCentury, Some(pattern), assignedDefaultTimeZone, isDefault)
     } else {
@@ -179,13 +182,14 @@ object DateTimePattern {
   }
 
   def apply(pattern: String,
-            assignedDefaultTimeZone: Option[String] = None): DateTimePattern = {
-    create(pattern, assignedDefaultTimeZone, isDefault = false)
+            assignedDefaultTimeZone: Option[String] = None,
+            isCenturyPattern: Boolean = false): DateTimePattern = {
+    create(pattern, assignedDefaultTimeZone, isCenturyPattern, isDefault = false)
   }
 
   def asDefault(pattern: String,
                 assignedDefaultTimeZone: Option[String] = None): DateTimePattern = {
-    create(pattern, assignedDefaultTimeZone, isDefault = true)
+    create(pattern, assignedDefaultTimeZone, isCenturyPattern = false, isDefault = true)
   }
 
   def isEpoch(pattern: String): Boolean = {

--- a/src/main/scala/za/co/absa/standardization/time/DateTimePattern.scala
+++ b/src/main/scala/za/co/absa/standardization/time/DateTimePattern.scala
@@ -17,6 +17,7 @@
 package za.co.absa.standardization.time
 
 import za.co.absa.standardization.implicits.StringImplicits.StringEnhancements
+import za.co.absa.standardization.time.DateTimePattern.{patternMicroSecondChar, patternMilliSecondChar, patternNanoSecondChat}
 import za.co.absa.standardization.types.{Section, TypePattern}
 
 /**
@@ -29,10 +30,12 @@ abstract sealed class DateTimePattern(pattern: String, isDefault: Boolean = fals
   extends TypePattern(pattern, isDefault){
 
   val isEpoch: Boolean
+  val isCentury: Boolean
   val epochFactor: Long
 
   val timeZoneInPattern: Boolean
   val defaultTimeZone: Option[String]
+  val originalPattern: Option[String]
   val isTimeZoned: Boolean
 
   val millisecondsPosition: Option[Section]
@@ -47,7 +50,6 @@ abstract sealed class DateTimePattern(pattern: String, isDefault: Boolean = fals
     val q = "\""
     s"pattern: $q$pattern$q" + defaultTimeZone.map(x => s" (default time zone: $q$x$q)").getOrElse("")
   }
-
 }
 
 object DateTimePattern {
@@ -56,6 +58,8 @@ object DateTimePattern {
   val EpochMilliKeyword = "epochmilli"
   val EpochMicroKeyword = "epochmicro"
   val EpochNanoKeyword = "epochnano"
+
+  val patternCenturyChar = "c"
 
   private val epochUnitFactor = 1
   private val epoch1kFactor = 1000
@@ -81,10 +85,12 @@ object DateTimePattern {
     extends DateTimePattern(pattern, isDefault) {
 
     override val isEpoch: Boolean = true
+    override val isCentury: Boolean = false
     override val epochFactor: Long = DateTimePattern.epochFactor(pattern)
 
     override val timeZoneInPattern: Boolean = true
     override val defaultTimeZone: Option[String] = None
+    override val originalPattern: Option[String] = None
     override val isTimeZoned: Boolean = true
 
     override val millisecondsPosition: Option[Section] = pattern match {
@@ -111,9 +117,9 @@ object DateTimePattern {
     override val patternWithoutSecondFractions: String = EpochKeyword
   }
 
-  private final case class StandardDTPattern(override val pattern: String,
-                                             assignedDefaultTimeZone: Option[String] = None,
-                                             override val isDefault: Boolean = false)
+  private abstract class StandardDTPatternBase(override val pattern: String,
+                                                      assignedDefaultTimeZone: Option[String],
+                                                      override val isDefault: Boolean = false)
     extends DateTimePattern(pattern, isDefault) {
 
     override val isEpoch: Boolean = false
@@ -143,9 +149,62 @@ object DateTimePattern {
     }
   }
 
+  private final case class StandardDTPattern(override val pattern: String,
+                                             assignedDefaultTimeZone: Option[String] = None,
+                                             override val isDefault: Boolean = false)
+    extends StandardDTPatternBase(pattern, assignedDefaultTimeZone, isDefault) {
+
+    override val isCentury: Boolean = false
+    override val originalPattern: Option[String] = None
+  }
+
+  private final case class CenturyDTPattern(override val pattern: String,
+                                            override val originalPattern: Option[String],
+                                            assignedDefaultTimeZone: Option[String] = None,
+                                            override val isDefault: Boolean = false)
+    extends StandardDTPatternBase(pattern, assignedDefaultTimeZone, isDefault) {
+
+    override val isCentury: Boolean = true
+  }
+
+//  private final case class StandardDTPattern(override val pattern: String,
+//                                             assignedDefaultTimeZone: Option[String] = None,
+//                                             override val isDefault: Boolean = false)
+//    extends DateTimePattern(pattern, isDefault) {
+//
+//    override val isEpoch: Boolean = false
+//    override val epochFactor: Long = 0
+//
+//    override val timeZoneInPattern: Boolean = DateTimePattern.timeZoneInPattern(pattern)
+//    override val defaultTimeZone: Option[String] = assignedDefaultTimeZone.filterNot(_ => timeZoneInPattern)
+//    override val isTimeZoned: Boolean = timeZoneInPattern || defaultTimeZone.nonEmpty
+//
+//    val (millisecondsPosition, microsecondsPosition, nanosecondsPosition) = analyzeSecondFractionsPositions(pattern)
+//    override val secondFractionsSections: Seq[Section] = Section.mergeTouchingSectionsAndSort(Seq(millisecondsPosition, microsecondsPosition, nanosecondsPosition).flatten)
+//    override val patternWithoutSecondFractions: String = Section.removeMultipleFrom(pattern, secondFractionsSections)
+//
+//    private def scanForPlaceholder(withinString: String, placeHolder: Char): Option[Section] = {
+//      val start = withinString.findFirstUnquoted(Set(placeHolder), Set('\''))
+//      start.map(index => Section.ofSameChars(withinString, index))
+//    }
+//
+//    private def analyzeSecondFractionsPositions(withinString: String): (Option[Section], Option[Section], Option[Section]) = {
+//      val clearedPattern = withinString
+//
+//      // TODO as part of #7 fix (originally Enceladus#677)
+//      val milliSP = scanForPlaceholder(clearedPattern, patternMilliSecondChar)
+//      val microSP = scanForPlaceholder(clearedPattern, patternMicroSecondChar)
+//      val nanoSP = scanForPlaceholder(clearedPattern, patternNanoSecondChat)
+//      (milliSP, microSP, nanoSP)
+//    }
+//  }
+
   private def create(pattern: String, assignedDefaultTimeZone: Option[String], isDefault: Boolean): DateTimePattern = {
     if (isEpoch(pattern)) {
       EpochDTPattern(pattern, isDefault)
+    } else if (isCentury(pattern)) {
+      val patternWithoutCentury = pattern.replaceAll(patternCenturyChar, "yy")
+      CenturyDTPattern(patternWithoutCentury, Some(pattern), assignedDefaultTimeZone, isDefault)
     } else {
       StandardDTPattern(pattern, assignedDefaultTimeZone, isDefault)
     }
@@ -166,6 +225,10 @@ object DateTimePattern {
       case EpochKeyword | EpochMilliKeyword | EpochMicroKeyword | EpochNanoKeyword => true
       case _ => false
     }
+  }
+
+  def isCentury(pattern: String): Boolean = {
+    pattern.contains(s"${patternCenturyChar}yy")
   }
 
   def epochFactor(pattern: String): Long = {

--- a/src/main/scala/za/co/absa/standardization/types/TypedStructField.scala
+++ b/src/main/scala/za/co/absa/standardization/types/TypedStructField.scala
@@ -415,6 +415,7 @@ object TypedStructField {
     private def readDateTimePattern: DateTimePattern = {
       structField.metadata.getOptString(MetadataKeys.Pattern).map { pattern =>
         val timeZoneOpt = structField.metadata.getOptString(MetadataKeys.DefaultTimeZone)
+        val centuryIndex = pattern.indexOf(DateTimePattern.patternCenturyChar) // TODO
         DateTimePattern(pattern, timeZoneOpt)
       }.getOrElse(
         DateTimePattern.asDefault(defaults.getStringPattern(structField.dataType), None)

--- a/src/main/scala/za/co/absa/standardization/types/TypedStructField.scala
+++ b/src/main/scala/za/co/absa/standardization/types/TypedStructField.scala
@@ -415,8 +415,8 @@ object TypedStructField {
     private def readDateTimePattern: DateTimePattern = {
       structField.metadata.getOptString(MetadataKeys.Pattern).map { pattern =>
         val timeZoneOpt = structField.metadata.getOptString(MetadataKeys.DefaultTimeZone)
-        val centuryIndex = pattern.indexOf(DateTimePattern.patternCenturyChar) // TODO
-        DateTimePattern(pattern, timeZoneOpt)
+        val isCenturyPattern = structField.metadata.getOptStringAsBoolean(MetadataKeys.IsCenturyPatter).getOrElse(false)
+        DateTimePattern(pattern, timeZoneOpt, isCenturyPattern)
       }.getOrElse(
         DateTimePattern.asDefault(defaults.getStringPattern(structField.dataType), None)
       )

--- a/src/main/scala/za/co/absa/standardization/types/TypedStructField.scala
+++ b/src/main/scala/za/co/absa/standardization/types/TypedStructField.scala
@@ -415,7 +415,7 @@ object TypedStructField {
     private def readDateTimePattern: DateTimePattern = {
       structField.metadata.getOptString(MetadataKeys.Pattern).map { pattern =>
         val timeZoneOpt = structField.metadata.getOptString(MetadataKeys.DefaultTimeZone)
-        val isCenturyPattern = structField.metadata.getOptStringAsBoolean(MetadataKeys.IsCenturyPatter).getOrElse(false)
+        val isCenturyPattern = structField.metadata.getOptStringAsBoolean(MetadataKeys.IsNonStandard).getOrElse(false)
         DateTimePattern(pattern, timeZoneOpt, isCenturyPattern)
       }.getOrElse(
         DateTimePattern.asDefault(defaults.getStringPattern(structField.dataType), None)

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
@@ -207,7 +207,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
       StructField(fieldName, DateType, nullable = false,
         new MetadataBuilder()
           .putString(MetadataKeys.Pattern, "cyy/dd/MM")
-          .putString("is_century_pattern", "true")
+          .putString(MetadataKeys.IsNonStandard, "true")
           .build)
     ))
     val exp: Seq[DateRow] = Seq(
@@ -236,7 +236,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
       StructField(fieldName, DateType, nullable = false,
         new MetadataBuilder()
           .putString(MetadataKeys.Pattern, "cyyddMM")
-          .putString("is_century_pattern", "true")
+          .putString(MetadataKeys.IsNonStandard, "true")
           .build)
     ))
     val exp: Seq[DateRow] = Seq(

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
@@ -207,6 +207,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
       StructField(fieldName, DateType, nullable = false,
         new MetadataBuilder()
           .putString(MetadataKeys.Pattern, "cyy/dd/MM")
+          .putString("is_century_pattern", "true")
           .build)
     ))
     val exp: Seq[DateRow] = Seq(
@@ -235,6 +236,7 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
       StructField(fieldName, DateType, nullable = false,
         new MetadataBuilder()
           .putString(MetadataKeys.Pattern, "cyyddMM")
+          .putString("is_century_pattern", "true")
           .build)
     ))
     val exp: Seq[DateRow] = Seq(

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
@@ -81,8 +81,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
         + "789123456789123456789123456791245678912324789123456789123456789123456789123456789123456791245678912324789123"
         + "456789123456789123456789123456789123456789123456789123456789.1"),
       ("06-Text", "foo", "bar"),
-      ("07-Exponential notation", "-1.23E4", "+9.8765E-3"),
-      ("08-Infinity", "FRRR", "MAXVALUE")
+      ("07-Exponential notation", "-1.23E4", "+9.8765E-3")
     )
     val src = seq.toDF("description","floatField", "doubleField")
     logDataFrameContent(src)
@@ -109,7 +108,6 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
         StandardizationErrorMessage.stdCastErr("floatField", "foo", "string", "float", None),
         StandardizationErrorMessage.stdCastErr("doubleField", "bar", "string", "double", None))),
       FractionalRow("07-Exponential notation", Option(-12300.0f), Option(0.0098765)),
-      FractionalRow("08-Infinity", Option(0f), Option(Double.PositiveInfinity))
     )
 
     assertResult(exp)(std.as[FractionalRow].collect().sortBy(_.description).toList)

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
@@ -107,7 +107,7 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
       FractionalRow("06-Text", Option(0), None, Seq(
         StandardizationErrorMessage.stdCastErr("floatField", "foo", "string", "float", None),
         StandardizationErrorMessage.stdCastErr("doubleField", "bar", "string", "double", None))),
-      FractionalRow("07-Exponential notation", Option(-12300.0f), Option(0.0098765)),
+      FractionalRow("07-Exponential notation", Option(-12300.0f), Option(0.0098765))
     )
 
     assertResult(exp)(std.as[FractionalRow].collect().sortBy(_.description).toList)

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_FractionalSuite.scala
@@ -81,7 +81,8 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
         + "789123456789123456789123456791245678912324789123456789123456789123456789123456789123456791245678912324789123"
         + "456789123456789123456789123456789123456789123456789123456789.1"),
       ("06-Text", "foo", "bar"),
-      ("07-Exponential notation", "-1.23E4", "+9.8765E-3")
+      ("07-Exponential notation", "-1.23E4", "+9.8765E-3"),
+      ("08-Infinity", "FRRR", "MAXVALUE")
     )
     val src = seq.toDF("description","floatField", "doubleField")
     logDataFrameContent(src)
@@ -107,7 +108,8 @@ class StandardizationInterpreter_FractionalSuite extends AnyFunSuite with SparkT
       FractionalRow("06-Text", Option(0), None, Seq(
         StandardizationErrorMessage.stdCastErr("floatField", "foo", "string", "float", None),
         StandardizationErrorMessage.stdCastErr("doubleField", "bar", "string", "double", None))),
-      FractionalRow("07-Exponential notation", Option(-12300.0f), Option(0.0098765))
+      FractionalRow("07-Exponential notation", Option(-12300.0f), Option(0.0098765)),
+      FractionalRow("08-Infinity", Option(0f), Option(Double.PositiveInfinity))
     )
 
     assertResult(exp)(std.as[FractionalRow].collect().sortBy(_.description).toList)

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
@@ -216,6 +216,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
       StructField(fieldName, TimestampType, nullable = false,
         new MetadataBuilder()
           .putString("pattern", "dd.MM.cyy HH-mm-ss")
+          .putString("is_century_pattern", "true")
           .build)
     ))
     val exp = Seq(
@@ -244,6 +245,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
       StructField(fieldName, TimestampType, nullable = false,
         new MetadataBuilder()
           .putString("pattern", "ddMMcyyHHmmss")
+          .putString("is_century_pattern", "true")
           .build)
     ))
     val exp = Seq(

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
@@ -216,7 +216,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
       StructField(fieldName, TimestampType, nullable = false,
         new MetadataBuilder()
           .putString("pattern", "dd.MM.cyy HH-mm-ss")
-          .putString("is_century_pattern", "true")
+          .putString(MetadataKeys.IsNonStandard, "true")
           .build)
     ))
     val exp = Seq(
@@ -245,7 +245,7 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
       StructField(fieldName, TimestampType, nullable = false,
         new MetadataBuilder()
           .putString("pattern", "ddMMcyyHHmmss")
-          .putString("is_century_pattern", "true")
+          .putString(MetadataKeys.IsNonStandard, "true")
           .build)
     ))
     val exp = Seq(

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
@@ -205,6 +205,62 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
     assertResult(exp)(std.as[TimestampRow].collect().toList)
   }
 
+  test("pattern up to seconds precision with century pattern from string") {
+    val seq  = Seq(
+      "01.01.070 00-00-00",
+      "02.01.070 00-00-00",
+      "31.12.100 23-59-59",
+      "16.07.119 14-41-43"
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, TimestampType, nullable = false,
+        new MetadataBuilder()
+          .putString("pattern", "dd.MM.cyy HH-mm-ss")
+          .build)
+    ))
+    val exp = Seq(
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00")),
+      TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00")),
+      TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59")),
+      TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43"))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[TimestampRow].collect().toList)
+  }
+
+  test("pattern up to seconds precision with century pattern fron int") {
+    val seq: Seq[Long] = Seq(
+      101070000000L,
+      201070000000L,
+      3112100235959L,
+      1607119144143L
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, TimestampType, nullable = false,
+        new MetadataBuilder()
+          .putString("pattern", "ddMMcyyHHmmss")
+          .build)
+    ))
+    val exp = Seq(
+      TimestampRow(Timestamp.valueOf("1970-01-01 00:00:00")),
+      TimestampRow(Timestamp.valueOf("1970-01-02 00:00:00")),
+      TimestampRow(Timestamp.valueOf("2000-12-31 23:59:59")),
+      TimestampRow(Timestamp.valueOf("2019-07-16 14:41:43"))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[TimestampRow].collect().toList)
+  }
+
   test("pattern up to seconds precision with default time zone") {
     val seq  = Seq(
       "31.12.1969 19-00-00",


### PR DESCRIPTION
Closes #64 

Add support for Mainframe's Century support. New DateTime pattern with `c`. 