### PR TITLE
* `InfinitySupport` changed from mix-in train to class

### DIFF
--- a/src/main/scala/za/co/absa/standardization/SchemaValidator.scala
+++ b/src/main/scala/za/co/absa/standardization/SchemaValidator.scala
@@ -18,7 +18,6 @@ package za.co.absa.standardization
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._
-import za.co.absa.standardization.ErrorMessage
 import za.co.absa.standardization.types.{TypeDefaults, TypedStructField}
 import za.co.absa.standardization.validation.field.FieldValidationIssue
 
@@ -116,7 +115,7 @@ object SchemaValidator {
             fields += prefixedField
         }
       }
-      fields.toSeq
+      fields
     }
 
     def flattenArray(field: StructField, arr: ArrayType, structPath: String): Seq[FlatField] = {
@@ -128,7 +127,7 @@ object SchemaValidator {
           val prefixedField = FlatField(structPath, field)
           arrayFields += prefixedField
       }
-      arrayFields.toSeq
+      arrayFields
     }
 
     flattenStruct(schema, "")

--- a/src/main/scala/za/co/absa/standardization/stages/InfinitySupportIso.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/InfinitySupportIso.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2025 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.standardization.stages
+
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{DataType, DateType, TimestampType}
+
+import java.text.SimpleDateFormat
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter.{ISO_DATE, ISO_DATE_TIME}
+import scala.util.Try
+
+abstract class InfinitySupportIso(
+                                   infMinusSymbol: Option[String],
+                                   infMinusValue: Option[String],
+                                   infPlusSymbol: Option[String],
+                                   infPlusValue: Option[String],
+                                   origType: DataType
+                                 ) extends InfinitySupport(infMinusSymbol, infMinusValue, infPlusSymbol, infPlusValue, origType) {
+
+  def isoCast(value: String): Column
+
+  def useIsoForInfMinus: Boolean
+  def useIsoForInfPlus: Boolean
+
+  def chooseInjectionFunction(isIso: Boolean, conversion: Column => Column, value: String): Column = {
+    if (isIso) {
+      isoCast(value)
+    } else {
+      conversion(defaultInfinityValueInjection(value))
+    }
+  }
+
+  override def executeReplacement(column: Column, conversion: Column => Column): Column = {
+    if (useIsoForInfMinus || useIsoForInfPlus) {
+      val columnWithNegativeInf = replaceSymbol(column, infMinusSymbol, infMinusValue, chooseInjectionFunction(useIsoForInfMinus, conversion, _))
+      val columnWithPositiveInf = replaceSymbol(columnWithNegativeInf, infPlusSymbol, infPlusValue, chooseInjectionFunction(useIsoForInfPlus, conversion, _))
+      columnWithPositiveInf.otherwise(conversion(column))
+    } else {
+      super.executeReplacement(column, conversion)
+    }
+  }
+}
+
+object InfinitySupportIso {
+  def apply(
+             infMinusSymbol: Option[String],
+             infMinusValue: Option[String],
+             infPlusSymbol: Option[String],
+             infPlusValue: Option[String],
+             origType: DataType,
+             targetType: DataType
+           ): InfinitySupportIso = {
+    targetType match {
+      case DateType => new InfinitySupportIsoDate(infMinusSymbol, infMinusValue, infPlusSymbol, infPlusValue, origType)
+      case TimestampType => new InfinitySupportIsoTimestamp(infMinusSymbol, infMinusValue, infPlusSymbol, infPlusValue, origType)
+      case _ => throw new IllegalArgumentException(s"InfinitySupportIso does not support target type $targetType")
+    }
+  }
+
+  def isOfISODateFormat(dateValue: Option[String]): Boolean = {
+    dateValue.exists(value =>
+      Try {
+        ISO_DATE.parse(value)
+      }.isSuccess)
+  }
+
+  def isOfISOTimestampFormat(timestampValue: Option[String]): Boolean = {
+    timestampValue.exists(value =>
+      Try {
+        OffsetDateTime.parse(value)
+      }.isSuccess)
+  }
+
+  class InfinitySupportIsoDate(
+                                infMinusSymbol: Option[String],
+                                infMinusValue: Option[String],
+                                infPlusSymbol: Option[String],
+                                infPlusValue: Option[String],
+                                origType: DataType
+                              ) extends InfinitySupportIso(infMinusSymbol, infMinusValue, infPlusSymbol, infPlusValue, origType) {
+    override def isoCast(value: String): Column = to_date(lit(value))
+    val useIsoForInfMinus: Boolean = isOfISODateFormat(infMinusValue)
+    val useIsoForInfPlus: Boolean = isOfISODateFormat(infPlusValue)
+  }
+
+  class InfinitySupportIsoTimestamp(
+                                     infMinusSymbol: Option[String],
+                                     infMinusValue: Option[String],
+                                     infPlusSymbol: Option[String],
+                                     infPlusValue: Option[String],
+                                     origType: DataType
+                                   ) extends InfinitySupportIso(infMinusSymbol, infMinusValue, infPlusSymbol, infPlusValue, origType) {
+    override def isoCast(value: String): Column = to_timestamp(lit(value))
+    val useIsoForInfMinus: Boolean = isOfISOTimestampFormat(infMinusValue)
+    val useIsoForInfPlus: Boolean = isOfISOTimestampFormat(infPlusValue)
+  }
+
+}
+
+

--- a/src/test/scala/za/co/absa/standardization/StandardizationCsvSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/StandardizationCsvSuite.scala
@@ -19,7 +19,6 @@ package za.co.absa.standardization
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
-import za.co.absa.standardization.ErrorMessage
 import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancements
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId

--- a/src/test/scala/za/co/absa/standardization/TestSamples.scala
+++ b/src/test/scala/za/co/absa/standardization/TestSamples.scala
@@ -16,7 +16,6 @@
 
 package za.co.absa.standardization
 
-import za.co.absa.standardization.ErrorMessage
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
 import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
 

--- a/src/test/scala/za/co/absa/standardization/stages/InfinitySupportIsoSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/stages/InfinitySupportIsoSuite.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2025 ABSA Group Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package za.co.absa.standardization.stages
+
+import org.scalatest.funsuite.AnyFunSuiteLike
+
+class InfinitySupportIsoSuite extends AnyFunSuiteLike {
+  test("No value is not an ISO date" ) {
+    assert(!InfinitySupportIso.isOfISODateFormat(None))
+  }
+
+  test("No value is not an ISO timestamp" ) {
+    assert(!InfinitySupportIso.isOfISOTimestampFormat(None))
+  }
+
+  test("Correctly detected the ISO date" ) {
+    assert(InfinitySupportIso.isOfISODateFormat(Some("2023-10-05")))
+  }
+
+  test("Correctly detected the ISO timestamp" ) {
+    assert(InfinitySupportIso.isOfISOTimestampFormat(Some("2023-10-05T12:34:56Z")))
+  }
+
+  test("Identified the date not being per ISO format" ) {
+    assert(!InfinitySupportIso.isOfISODateFormat(Some("10.5.23")))
+  }
+
+  test("Identified the timestamp not being per ISO format" ) {
+    assert(!InfinitySupportIso.isOfISOTimestampFormat(Some("12-34-56 31.12.03")))
+  }
+}


### PR DESCRIPTION
* created `InfinitySupportIso` for support of Iso pattern fallback in date and timestamp parsing
* Integrated the new class into `TypeParser` instead of using it as trait
* Removed some compilation warnings