### PR TITLE
#93 : failures on parsing timestamp with timezone

### DIFF
--- a/src/main/scala/za/co/absa/standardization/time/DateTimePattern.scala
+++ b/src/main/scala/za/co/absa/standardization/time/DateTimePattern.scala
@@ -158,7 +158,8 @@ object DateTimePattern {
     ): (Option[Section], Option[Section], Option[Section]) = {
       def adjust(sectionOpt: Option[Section]): Option[Section] = {
         sectionOpt.map { s =>
-          val quotesBefore = pat.substring(0, s.start).count(_ == '\'')
+          val prefix = pat.substring(0, s.start)
+          val quotesBefore = prefix.countUnquoted(Set('\''), Set.empty).getOrElse('\'', 0)
           s.copy(start = s.start - quotesBefore)
         }
       }

--- a/src/main/scala/za/co/absa/standardization/time/DateTimePattern.scala
+++ b/src/main/scala/za/co/absa/standardization/time/DateTimePattern.scala
@@ -129,23 +129,40 @@ object DateTimePattern {
     override val defaultTimeZone: Option[String] = assignedDefaultTimeZone.filterNot(_ => timeZoneInPattern)
     override val isTimeZoned: Boolean = timeZoneInPattern || defaultTimeZone.nonEmpty
 
-    val (millisecondsPosition, microsecondsPosition, nanosecondsPosition) = analyzeSecondFractionsPositions(pattern)
+    private val (patternMilliPos, patternMicroPos, patternNanoPos) = scanSecondFractionsInPattern(pattern)
+    override val patternWithoutSecondFractions: String = {
+      val patternSections = Section.mergeTouchingSectionsAndSort(Seq(patternMilliPos, patternMicroPos, patternNanoPos).flatten)
+      Section.removeMultipleFrom(pattern, patternSections)
+    }
+
+    val (millisecondsPosition, microsecondsPosition, nanosecondsPosition) = adjustPositionsForValue(pattern, patternMilliPos, patternMicroPos, patternNanoPos)
     override val secondFractionsSections: Seq[Section] = Section.mergeTouchingSectionsAndSort(Seq(millisecondsPosition, microsecondsPosition, nanosecondsPosition).flatten)
-    override val patternWithoutSecondFractions: String = Section.removeMultipleFrom(pattern, secondFractionsSections)
 
     private def scanForPlaceholder(withinString: String, placeHolder: Char): Option[Section] = {
       val start = withinString.findFirstUnquoted(Set(placeHolder), Set('\''))
       start.map(index => Section.ofSameChars(withinString, index))
     }
 
-    private def analyzeSecondFractionsPositions(withinString: String): (Option[Section], Option[Section], Option[Section]) = {
-      val clearedPattern = withinString
-
-      // TODO as part of #7 fix (originally Enceladus#677)
-      val milliSP = scanForPlaceholder(clearedPattern, patternMilliSecondChar)
-      val microSP = scanForPlaceholder(clearedPattern, patternMicroSecondChar)
-      val nanoSP = scanForPlaceholder(clearedPattern, patternNanoSecondChat)
+    private def scanSecondFractionsInPattern(withinString: String): (Option[Section], Option[Section], Option[Section]) = {
+      val milliSP = scanForPlaceholder(withinString, patternMilliSecondChar)
+      val microSP = scanForPlaceholder(withinString, patternMicroSecondChar)
+      val nanoSP = scanForPlaceholder(withinString, patternNanoSecondChat)
       (milliSP, microSP, nanoSP)
+    }
+
+    private def adjustPositionsForValue(
+      pat: String,
+      milliPos: Option[Section],
+      microPos: Option[Section],
+      nanoPos: Option[Section]
+    ): (Option[Section], Option[Section], Option[Section]) = {
+      def adjust(sectionOpt: Option[Section]): Option[Section] = {
+        sectionOpt.map { s =>
+          val quotesBefore = pat.substring(0, s.start).count(_ == '\'')
+          s.copy(start = s.start - quotesBefore)
+        }
+      }
+      (adjust(milliPos), adjust(microPos), adjust(nanoPos))
     }
   }
 

--- a/src/test/scala/za/co/absa/standardization/time/DateTimePatternSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/time/DateTimePatternSuite.scala
@@ -268,4 +268,15 @@ class DateTimePatternSuite extends AnyFunSuite {
     assert(dtp.patternWithoutSecondFractions == "yyyy-MM-dd HH:mm:ss")
     assert(!dtp.containsSecondFractions)
   }
+
+  test("Second fractions detection in regular pattern with quoted literal - milliseconds") {
+    val pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX"
+    val dtp = DateTimePattern(pattern)
+    assert(dtp.millisecondsPosition.contains(Section(20, 3)))
+    assert(dtp.microsecondsPosition.isEmpty)
+    assert(dtp.nanosecondsPosition.isEmpty)
+    assert(dtp.secondFractionsSections == Seq(Section(20, 3)))
+    assert(dtp.patternWithoutSecondFractions == "yyyy-MM-dd'T'HH:mm:ss.XXX")
+    assert(dtp.containsSecondFractions)
+  }
 }

--- a/src/test/scala/za/co/absa/standardization/types/parsers/DateTimeParserSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/types/parsers/DateTimeParserSuite.scala
@@ -18,6 +18,7 @@ package za.co.absa.standardization.types.parsers
 
 import java.sql.{Date, Timestamp}
 import java.text.{ParseException, SimpleDateFormat}
+import java.util.TimeZone
 
 import org.scalatest.funsuite.AnyFunSuite
 import za.co.absa.standardization.testing.TimeZoneNormalizer
@@ -26,6 +27,7 @@ case class TestInputRow(id: Int, stringField: String)
 
 class DateTimeParserSuite extends AnyFunSuite{
 
+  TimeZone.setDefault(TimeZone.getTimeZone("UTC"))
   TimeZoneNormalizer.normalizeJVMTimeZone()
 
   test("DateParser class epoch") {

--- a/src/test/scala/za/co/absa/standardization/types/parsers/DateTimeParserSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/types/parsers/DateTimeParserSuite.scala
@@ -20,10 +20,13 @@ import java.sql.{Date, Timestamp}
 import java.text.{ParseException, SimpleDateFormat}
 
 import org.scalatest.funsuite.AnyFunSuite
+import za.co.absa.standardization.testing.TimeZoneNormalizer
 
 case class TestInputRow(id: Int, stringField: String)
 
 class DateTimeParserSuite extends AnyFunSuite{
+
+  TimeZoneNormalizer.normalizeJVMTimeZone()
 
   test("DateParser class epoch") {
     val parser = DateTimeParser("epoch")

--- a/src/test/scala/za/co/absa/standardization/types/parsers/DateTimeParserSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/types/parsers/DateTimeParserSuite.scala
@@ -186,6 +186,19 @@ class DateTimeParserSuite extends AnyFunSuite{
     assert(parser7.format(t) == "(789) 1970-01-02 (123) 01:00:00 (456)")
   }
 
+  test("DateParser class actual pattern with quoted literal and timezone and milliseconds") {
+    val parser = DateTimeParser("yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    val str = "2025-07-18T16:07:51.569+02:00"
+
+    val resultDate: Date = parser.parseDate(str)
+    val expectedDate: Date = Date.valueOf("2025-07-18")
+    assert(resultDate == expectedDate)
+
+    val resultTimestamp: Timestamp = parser.parseTimestamp(str)
+    val expectedTimestamp: Timestamp = Timestamp.valueOf("2025-07-18 14:07:51.569")
+    assert(resultTimestamp == expectedTimestamp)
+  }
+
   test("Lenient interpretation is not accepted") {
     //first lenient interpretation
     val pattern = "dd-MM-yyyy"


### PR DESCRIPTION
Release notes:

- Bugfix  parsing timestamp  with timezone  addressed by removing the number of single-quote characters that appear before each section's start in the pattern

closes https://github.com/AbsaOSS/spark-data-standardization/issues/93