### PR TITLE
#100 Add null check when standardizing struct fields.

### DIFF
--- a/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
@@ -26,7 +26,6 @@ import za.co.absa.spark.commons.implicits.StructFieldImplicits.StructFieldMetada
 import za.co.absa.spark.commons.implicits.StructTypeImplicits.StructTypeEnhancements
 import za.co.absa.spark.commons.utils.SchemaUtils
 import za.co.absa.spark.hofs.transform
-import za.co.absa.standardization.{ErrorMessage, StandardizationErrorMessage}
 import za.co.absa.standardization.config.StandardizationConfig
 import za.co.absa.standardization.implicits.StdColumnImplicits.StdColumnEnhancements
 import za.co.absa.standardization.schema.StdSchemaUtils.FieldWithSource
@@ -34,9 +33,9 @@ import za.co.absa.standardization.schema.{MetadataKeys, MetadataValues, StdSchem
 import za.co.absa.standardization.time.DateTimePattern
 import za.co.absa.standardization.typeClasses.{DoubleLike, LongLike}
 import za.co.absa.standardization.types.TypedStructField._
-import za.co.absa.standardization.types.parsers.DateTimeParser
 import za.co.absa.standardization.types.{ParseOutput, TypeDefaults, TypedStructField}
 import za.co.absa.standardization.udf.{UDFBuilder, UDFNames}
+import za.co.absa.standardization.{ErrorMessage, StandardizationErrorMessage}
 
 import java.security.InvalidParameterException
 import java.sql.Timestamp
@@ -257,7 +256,7 @@ object TypeParser {
           )
       )
       // rebuild the struct
-      val outputColumn = struct(cols: _*) as (fieldOutputName, metadata)
+      val outputColumn = when(column.isNull, lit(null)).otherwise(struct(cols: _*)) as (fieldOutputName, metadata)
 
       ParseOutput(outputColumn, errs1)
     }

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreterSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreterSuite.scala
@@ -49,6 +49,9 @@ object StandardizationInterpreterSuite {
   case class subarrayCC(arrayFieldA: Integer, arrayFieldB: String, arrayStruct: subCC)
   case class rootCC(rootField: String, rootStruct: subCC, rootStruct2: sub1CC, rootArray: Array[subarrayCC])
 
+  case class InnerStruct(innerA: String, innerB: Integer)
+  case class NullStructRecord(id: Long, name: Option[String], details: Option[InnerStruct])
+
   // used by the last test:
   // cannot use case class as the field names contain spaces therefore cast will happen into tuple
   type BodyStats = (Int, Int, (String, Option[Boolean]), Seq[Double])
@@ -223,6 +226,37 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
     val count = standardizedDF.where(size(col("errCol")) > 0).count()
 
     assert(count == 0)
+  }
+
+  test("Test standardization preserves null for a nullable nested struct") {
+    val schema = StructType(
+      Array(
+        StructField("id", LongType, nullable = false),
+        StructField("name", StringType, nullable = true),
+        StructField("details", StructType(Array(
+          StructField("innerA", StringType, nullable = false),
+          StructField("innerB", IntegerType, nullable = false)
+        )), nullable = true)))
+
+    val sourceDF = spark.createDataFrame(
+      Array(
+        NullStructRecord(1, Some("Record 1"), Some(InnerStruct("hello", 42))),
+        NullStructRecord(2, Some("Record 2"), None),
+        NullStructRecord(3, None, None)
+      ))
+
+    val standardizedDF = Standardization.standardize(sourceDF, schema, stdConfig)
+
+    // No errors should be produced since the struct is nullable
+    val errorCount = standardizedDF.where(size(col("errCol")) > 0).count()
+    assert(errorCount == 0)
+
+    // Verify that null struct values remain null in the output
+    val dfStandardized = standardizedDF.orderBy("id")
+    val detailsValues = dfStandardized.select("details").collect()
+    assert(detailsValues(0).getStruct(0) != null, "Record 1 should have a non-null details struct")
+    assert(detailsValues(1).isNullAt(0), "Record 2 should have a null details struct in the output")
+    assert(detailsValues(2).isNullAt(0), "Record 3 should have a null details struct in the output")
   }
 
   test ("Test standardization of Date and Timestamp fields with default value and pattern") {

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreterSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreterSuite.scala
@@ -23,10 +23,10 @@ import za.co.absa.spark.commons.implicits.DataFrameImplicits.DataFrameEnhancemen
 import za.co.absa.spark.commons.test.SparkTestBase
 import za.co.absa.spark.commons.utils.JsonUtils
 import za.co.absa.standardization.RecordIdGeneration.IdType.NoId
-import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, DefaultStandardizationConfig, ErrorCodesConfig}
+import za.co.absa.standardization._
+import za.co.absa.standardization.config.{BasicMetadataColumnsConfig, BasicStandardizationConfig, ErrorCodesConfig}
 import za.co.absa.standardization.types.{CommonTypeDefaults, TypeDefaults}
 import za.co.absa.standardization.udf.UDFLibrary
-import za.co.absa.standardization._
 
 import java.sql.{Date, Timestamp}
 import java.util.TimeZone
@@ -97,7 +97,7 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
         StructType(
           Seq(
             StructField("subFieldA", IntegerType, nullable = true),
-            StructField("subFieldB", StringType, nullable = true))), nullable = false),
+            StructField("subFieldB", StringType, nullable = true))), nullable = true),
       StructField("rootStruct2",
         StructType(
           Seq(
@@ -105,7 +105,7 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
               StructType(
                 Seq(
                   StructField("subSub2FieldA", IntegerType, nullable = true),
-                  StructField("subSub2FieldB", StringType, nullable = true))), nullable = false))), nullable = false),
+                  StructField("subSub2FieldB", StringType, nullable = true))), nullable = true))), nullable = true),
       StructField("rootArray",
         ArrayType(
           StructType(
@@ -116,7 +116,7 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
                 StructType(
                   Seq(
                     StructField("subFieldA", IntegerType, nullable = true),
-                    StructField("subFieldB", StringType, nullable = true))), nullable = false))), containsNull = false
+                    StructField("subFieldB", StringType, nullable = true))), nullable = true))), containsNull = true
         ))))
 
   test("Non-null errors produced for non-nullable attribute in a struct") {
@@ -357,10 +357,10 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
     val expectedSchema = "root\n" +
       " |-- first_name: string (nullable = true)\n" +
       " |-- last_name: string (nullable = true)\n" +
-      " |-- body_stats: struct (nullable = false)\n" +
+      " |-- body_stats: struct (nullable = true)\n" +
       " |    |-- height: integer (nullable = true)\n" +
       " |    |-- weight: integer (nullable = true)\n" +
-      " |    |-- miscellaneous: struct (nullable = false)\n" +
+      " |    |-- miscellaneous: struct (nullable = true)\n" +
       " |    |    |-- eye_color: string (nullable = true)\n" +
       " |    |    |-- glasses: boolean (nullable = true)\n" +
       " |    |-- temperature_measurements: array (nullable = true)\n" +


### PR DESCRIPTION
This improves the performance of processing of multi-segment mainframe files.

### Implications
#### Before
When an input `struct` was `null` it was converted to a struct with all fields are `null`. Note that there is no possibility (to the best of my knowledge) to add a default value for a struct, and it rarely makes sense.  

#### After
When an input `struct` was `null` the output struct is going to be also `null` making that schema field nullable.

## Test Evidence

Tested on one of problematic pipelines that takes too long to standardize. Tested both in UAT and PROD.

Change: 
- UAT volumes: from `00:35:44` to `00:22:00`
- Prod volumes: from `04:24:53` to `02:43:16`

Around 37% improvement in both cases.

### Before the change
<table style="width:100%">
<thead><tr><th>Job</th>
<th>Table</th>
<th>Catalog</th>
<th>Date</th>
<th>Record Count</th>
<th>Elapsed Time</th>
<th>Size</th>
<th>Throughput</th>
<th>Saved at</th>
<th>Status</th>
<th>Reason</th></tr></thead>
<tbody>
<tr><td style="font-style: italic;">Standardize</td>
<td style="font-style: italic;">abc.PIPELINE_prepublish</td>
<td></td>
<td style="text-align:center">2026-05-23</td>
<td style="text-align:right">217638680</td>
<td style="text-align:center">04:24:53</td>
<td style="text-align:right">29 GiB</td>
<td style="text-align:right">13694 r/s</td>
<td style="text-align:center">2026-05-24 10:07 +0200</td>
<td class="tdgreen" style="text-align:center">Success</td>
<td></td></tr>
</table>
### After the change
<table style="width:100%">
<thead><tr><th>Job</th>
<th>Table</th>
<th>Catalog</th>
<th>Date</th>
<th>Record Count</th>
<th>Elapsed Time</th>
<th>Size</th>
<th>Throughput</th>
<th>Saved at</th>
<th>Status</th>
<th>Reason</th></tr></thead>
<tbody>
<tr><td style="font-style: italic;">Standardize</td>
<td style="font-style: italic;">abc.PIPELINE_prepublish</td>
<td></td>
<td style="text-align:center">2026-05-23</td>
<td style="text-align:right">217638680</td>
<td style="text-align:center">02:43:16</td>
<td style="text-align:right">31 GiB</td>
<td style="text-align:right">22217 r/s</td>
<td style="text-align:center">2026-05-25 17:21 +0200</td>
<td class="tdgreen" style="text-align:center">Success</td>
<td></td></tr>
</table>

Closes #100