### PR TITLE
Updating Java Method Filtration JaCoCo Extension

### DIFF
--- a/.github/workflows/jacoco_check.yml
+++ b/.github/workflows/jacoco_check.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Add JaCoCo Report in PR comments
         id: jacoco
-        uses: MoranaApps/jacoco-report@ffdcfb247c26a483486d5b2cfe055bb6d735f68a
+        uses: MoranaApps/jacoco-report@3be109b40946547c5925e63d41fef1099c9e562b
         with:
           paths: |
             **/jacoco.xml

--- a/.github/workflows/jacoco_check.yml
+++ b/.github/workflows/jacoco_check.yml
@@ -66,7 +66,8 @@ jobs:
           paths: |
             **/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          global-thresholds: '${{ matrix.overall }}*${{ matrix.changed }}*${{ matrix.per-changed-file}}'
+          global-thresholds: '${{ matrix.overall }}*${{ matrix.changed }}'
+          report-thresholds-default: '${{ matrix.overall }}*${{ matrix.changed }}*${{ matrix.per-changed-file }}'
           title: JaCoCo code coverage report - scala ${{ matrix.scala }}
           update-comment: true
 

--- a/.github/workflows/jacoco_check.yml
+++ b/.github/workflows/jacoco_check.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Add JaCoCo Report in PR comments
         id: jacoco
-        uses: MoranaApps/jacoco-report@69351d88d18f7697c416e1bc2020ed05606d8120
+        uses: MoranaApps/jacoco-report@ffdcfb247c26a483486d5b2cfe055bb6d735f68a
         with:
           paths: |
             **/jacoco.xml

--- a/.github/workflows/jacoco_check.yml
+++ b/.github/workflows/jacoco_check.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Add JaCoCo Report in PR comments
         id: jacoco
-        uses: MoranaApps/jacoco-report@54bfe284d1119dc917dddba80517c54c5bcf3627
+        uses: MoranaApps/jacoco-report@69351d88d18f7697c416e1bc2020ed05606d8120
         with:
           paths: |
             **/jacoco.xml

--- a/.github/workflows/jacoco_check.yml
+++ b/.github/workflows/jacoco_check.yml
@@ -35,7 +35,7 @@ jobs:
           - scala: 2.12.20
             scalaShort: "2.12"
             overall: 80.0
-            changed: 80.0
+            changed: 60.0
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/jacoco_check.yml
+++ b/.github/workflows/jacoco_check.yml
@@ -49,6 +49,11 @@ jobs:
         with:
           java-version: "adopt@1.11"
 
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.14"
+
       - name: Build and run tests
         run: sbt ++${{matrix.scala}} jacoco
 

--- a/.github/workflows/jacoco_check.yml
+++ b/.github/workflows/jacoco_check.yml
@@ -35,7 +35,9 @@ jobs:
           - scala: 2.12.20
             scalaShort: "2.12"
             overall: 80.0
-            changed: 60.0
+            changed: 80.0
+            per-changed-file: 60.0
+
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
@@ -64,8 +66,7 @@ jobs:
           paths: |
             **/jacoco.xml
           token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: ${{ matrix.overall }}
-          min-coverage-changed-files: ${{ matrix.changed }}
+          global-thresholds: '${{ matrix.overall }}*${{ matrix.changed }}*${{ matrix.per-changed-file}}'
           title: JaCoCo code coverage report - scala ${{ matrix.scala }}
           update-comment: true
 

--- a/build.sbt
+++ b/build.sbt
@@ -66,12 +66,9 @@ Global / excludeLintKeys += ThisBuild / name // will be used in publish, todo #3
 
 // JaCoCo Method Filter Plugin
 enablePlugins(JacocoFilterPlugin)
-
 jacocoReportName := s"spark-data-standardization Jacoco Report - scala:${scalaVersion.value}"
 jacocoReportFormats := Set("html", "xml")
-
 // jacocoExcludes := Seq("za/co/absa/standardization/udf/UDFBuilder*", "za/co/absa/standardization/udf/UDFNames")
-
 // Command aliases for JaCoCo coverage workflow
 addCommandAlias("jacoco", "; jacocoOn; clean; test; jacocoReportAll; jacocoOff")
 addCommandAlias("jacocoOn", "; set every jacocoPluginEnabled := true")

--- a/jmf-rules.txt
+++ b/jmf-rules.txt
@@ -1,5 +1,5 @@
 # jacoco-method-filter — Rules Template AbsaOSS/spark-data-standardization
-# [jmf:2.1.1]
+# [jmf:2.2.0]
 #
 # Syntax reference, pitfalls, examples, and workflows: https://github.com/MoranaApps/jacoco-method-filter/blob/main/docs/rules-reference.md
 #
@@ -142,11 +142,6 @@
 +za.co.absa.standardization.time.DateTimePattern$#isEpoch(*)              id:std-include-datetime-pattern-is-epoch
 
 +za.co.absa.standardization.stages.InfinitySupport$#apply(*)              id:std-include-infinity-support-apply
-
-+za.co.absa.standardization.config.BasicErrorCodesConfig$#fromDefault(*)  id:std-include-basic-error-codes-from-default
-+za.co.absa.standardization.config.BasicMetadataColumnsConfig$#fromDefault(*) id:std-include-basic-metadata-columns-from-default
-
-+za.co.absa.standardization.ErrorMessage$#errorColSchema(*)               id:std-include-error-message-error-col-schema
 
 # ─────────────────────────────────────────────────────────────────────────────
 # PROJECT RULES

--- a/jmf-rules.txt
+++ b/jmf-rules.txt
@@ -1,118 +1,25 @@
-# jacoco-method-filter — Default Rules & HowTo (Scala)
-# [jmf:1.0.0]
+# jacoco-method-filter — Rules Template (Scala / sbt)
+# [jmf:2.1.0]
 #
-# This file defines which methods should be annotated as *Generated so JaCoCo ignores them.
-# One rule per line.
-#
-# ─────────────────────────────────────────────────────────────────────────────
-# HOW TO USE (quick)
-# 1) Replace YOUR.PACKAGE.ROOT with your project’s package root (e.g., com.example.app).
-# 2) Start with the CONSERVATIVE section only.
-# 3) If clean, enable STANDARD. Use AGGRESSIVE only inside DTO/auto‑generated packages.
-# 4) Keep rules narrow (by package), prefer flags (synthetic/bridge) for compiler artifacts,
-#    and add `id:` labels so logs are easy to read.
+# Syntax reference, pitfalls, examples, and workflows: https://github.com/MoranaApps/jacoco-method-filter/blob/main/docs/rules-reference.md
 #
 # ─────────────────────────────────────────────────────────────────────────────
-# ALLOWED SYNTAX (cheat sheet)
+# HOW TO USE
+# ─────────────────────────────────────────────────────────────────────────────
 #
-# General form:
-#   <FQCN_glob>#<method_glob>(<descriptor_glob>) [FLAGS and PREDICATES...]
-#
-# FQCN_glob (dot form; $ allowed for inner classes):
-#   Examples:  *.model.*,  com.example.*,  *
-#
-# method_glob (glob on method name):
-#   Examples:  copy   |   $anonfun$*   |   get*   |   *_$eq
-#
-# descriptor_glob (JVM descriptor in (args)ret). You may omit it entirely.
-#   • Omitting descriptor ⇒ treated as "(*)*" (any args, any return).
-#   • Short/empty forms "", "()", "(*)" normalize to "(*)*".
-#   Examples:
-#     (I)I                      # takes int, returns int
-#     (Ljava/lang/String;)V     # takes String, returns void
-#     ()  or  (*)  or omitted  # any args, any return
-#
-# FLAGS (optional) — space or comma separated:
-#   public | protected | private | synthetic | bridge | static | abstract
-#
-# PREDICATES (optional):
-#   ret:<glob>          # match return type only (e.g., ret:V, ret:I, ret:Lcom/example/*;)
-#   id:<string>         # identifier shown in logs/reports
-#   name-contains:<s>   # method name must contain <s>
-#   name-starts:<s>     # method name must start with <s>
-#   name-ends:<s>       # method name must end with <s>
-#
-# Notes
-# - Always use dot-form (com.example.Foo) for class names.
-# - Comments (# …) and blank lines are ignored.
+# 1) Review the GLOBAL RULES below — they cover compiler-generated boilerplate.
+# 2) Add project-specific patterns in the PROJECT RULES section.
+# 3) Keep rules narrow; add id: labels so logs are readable.
+#    Every rule must have an id:<label>. Unlabelled rules emit a [warn] at load
+#    time. CLI users: pass --strict to enforce id: as a hard CI requirement.
+#    (sbt/Maven plugins do not yet expose --strict as a configuration key.)
+# 4) Use --verify mode to confirm rules match before committing.
 #
 # ─────────────────────────────────────────────────────────────────────────────
-# QUICK EXAMPLES
-#
-# Simple wildcards
-#   *#*(*)
-#     → Match EVERY method in EVERY class (any package). Useful only for diagnostics.
-#       "(*)" normalizes to "(*)*" ⇒ any args, any return.
-#   *.dto.*#*(*)
-#     → Match every method on any class under any package segment named "dto".
-#       Good when you treat DTOs as generated/boilerplate.
-
-# Scala case class helpers
-#   *.model.*#copy(*)
-#     → Matches Scala case-class `copy` methods under `*.model.*`.
-#       Hides boilerplate clones with any parameter list and any return.
-#   *.model.*#productArity()
-#     → Matches zero-arg `productArity` (case-class/Product API).
-#   *.model.*#productElement(*)
-#     → Matches `productElement(int)` (or any descriptor form) on case classes.
-#   *.model.*#productPrefix()
-#     → Matches `productPrefix()`; returns the case class' constructor name.
-
-# Companion objects and defaults
-#   *.model.*$*#apply(*)
-#     → Matches companion `apply` factories under `*.model.*` (any args).
-#       BE CAREFUL: can hide real factory logic; keep the package scope narrow.
-#   *.model.*$*#unapply(*)
-#     → Matches extractor `unapply` methods in companions under `*.model.*`.
-#   *#*$default$*(*)
-#     → Matches Scala-generated default-argument helpers everywhere.
-#       Safe to keep enabled; they’re compiler-synthesized.
-
-# Anonymous / synthetic / bridge
-#   *#$anonfun$*
-#     → Matches any method whose name contains `$anonfun$` (Scala lambdas).
-#       Consider adding `synthetic` and/or a package scope in real configs.
-#   *#*(*):synthetic            # any synthetic
-#     → Matches ANY method marked `synthetic` (compiler-generated).
-#       Powerful; scope by package to avoid hiding intentional glue code.
-#   *#*(*):bridge               # any bridge
-#     → Matches Java generic bridge methods the compiler inserts.
-#       Usually safe globally, but scoping is still recommended.
-
-# Setters / fluent APIs
-#   *.dto.*#*_$eq(*)
-#     → Matches Scala var setters in DTO packages (e.g., `name_=(...)`).
-#       Good for excluding trivial field writes.
-#   *.builder.*#with*(*)
-#     → Matches builder-style fluent setters (`withXxx(...)`) in builder pkgs.
-#       Treats chainable configuration as boilerplate.
-#   *.client.*#with*(*) ret:Lcom/api/client/*
-#     → Like above but ONLY when the return type matches your client package.
-#       The `ret:` predicate protects real logic that returns other types.
-
-# Return-type constraints
-#   *.jobs.*#*(*):ret:V
-#     → Any method under `*.jobs.*` returning `void` (`V`). Often orchestration.
-#   *.math.*#*(*):ret:I
-#     → Any method under `*.math.*` returning primitive int (`I`).
-#   *.model.*#*(*):ret:Lcom/example/model/*
-#     → Any method under `*.model.*` that returns a type in `com.example.model`.
-#       Handy when the *return type* uniquely identifies boilerplate.
-
+# GLOBAL RULES
 # ─────────────────────────────────────────────────────────────────────────────
-# GLOBALS RULES
-# ─────────────────────────────────────────────────────────────────────────────
-# ** all case class boilerplate
+# Global rules match ALL packages. Verify they do not suppress real logic.
+# See docs/rules-reference.md#global-rule-safety-warning for details.
 
 # Scala case class helpers
 *#canEqual(*)                                           id:case-canequal
@@ -121,6 +28,7 @@
 *#unapply(*)                                            id:case-unapply
 *#hashCode(*)                                           id:case-hashcode
 *#copy(*)                                               id:case-copy
+# Subsumed by gen-defaults below; kept for clarity. Safe to remove if gen-defaults is enabled.
 *#copy$default$*(*)                                     id:case-copy-defaults
 *#productElement()                                      id:case-prod-element
 *#productArity()                                        id:case-prod-arity
@@ -129,13 +37,23 @@
 *#tupled()                                              id:case-tupled
 *#curried()                                             id:case-curried
 *#toString()                                            id:case-tostring
-*#name()                                                id:case-name
-*#groups()                                              id:case-groups
-*#optionalAttributes()                                  id:case-optionalAttributes
+# Scala 2.13+ case class boilerplate — safe to enable; no-op in 2.11/2.12
+# Note: unmatched
+#*#productElementName(*)                                 id:case-prod-element-name
+#*#productElementNames()                                 id:case-prod-element-names
+# WARNING: may collide with domain methods named `name` — rescue with + include rule if needed
+# Note: unmatched
+#*#name()                                                id:case-name
+# WARNING: may collide with domain methods named `groups` — rescue with + include rule if needed
+# Note: unmatched
+#*#groups()                                              id:case-groups
+# WARNING: may collide with domain methods named `optionalAttributes` — rescue with + include rule if needed
+# Note: unmatched
+#*#optionalAttributes()                                  id:case-optionalAttributes
 
 # Companion objects, constructors, and static definitions
-*$#<init>(*)                                            id:gen-ctor         # constructors
-*$#<clinit>()                                           id:gen-clinit       # static initializer blocks
+*$#<init>(*)                                            id:gen-ctor
+*$#<clinit>()                                           id:gen-clinit
 
 # Companion objects and defaults
 *$*#apply(*)                                            id:comp-apply
@@ -143,12 +61,69 @@
 *$*#toString(*)                                         id:comp-tostring
 *$*#readResolve(*)                                      id:comp-readresolve
 
+# Java serialization hook — compiler-generated on the case class itself (not the companion)
+# Body is a single expression returning a serialization proxy; no project logic.
+# WARNING: if a class overrides writeReplace with custom logic, rescue with + include rule.
+# Note: unmatched
+#*#writeReplace(*)                                       id:case-writereplace
+
 # anonymous class created by a macro expansion
-*$macro$*#$anonfun$inst$macro$*                         id:macro-inst
-*$macro$*#inst$macro$*                                  id:macro-inst
+# Note: unmatched
+#*$macro$*#$anonfun$inst$macro$*                         id:macro-inst
+#*$macro$*#inst$macro$*                                  id:macro-inst
 
 # lambda
 *#*  synthetic name-contains:$anonfun$                  id:scala-anonfun
+
+# Lazy val compute — compiler-generated synchronization wrapper
+# Scala compiles `lazy val foo = expr` into an accessor + a `foo$lzycompute()` method.
+# The $lzycompute method body IS the lazy initializer (expr). If the initializer contains
+# real business logic, filtering this method hides it. Only enable when the lazy val is a
+# trivial constant, a boundary call not unit-testable, or an already-tested computation.
+# Rescue any lazy vals with real logic via + include rules.
+# DISABLED — enable with + include rules to rescue lazy vals whose initializer has real logic
+# *#*$lzycompute(*)                                      id:scala-lzycompute
+
+# Lambda serialization helper — compiler-generated private static method
+# Emitted by scalac/javac to support SerializedLambda deserialization.
+# NOT marked ACC_SYNTHETIC (unlike $anonfun$*), so the synthetic flag does not catch it.
+# Body contains only a series of instanceof/handle comparisons — no project logic.
+*#$deserializeLambda$(*)                                id:scala-deser-lambda
+
+# Value class companion extension bridges — compiler-generated identity operations
+# When a value class (AnyVal) is used in a boxed context, the Scala compiler emits
+# these *$extension methods on the companion object. Each is a single-expression
+# delegate to the unboxed static method; no project logic is present.
+*#hashCode$extension(*)                                 id:valclass-hashcode-ext
+*#equals$extension(*)                                   id:valclass-equals-ext
+*#toString$extension(*)                                 id:valclass-tostring-ext
+*#canEqual$extension(*)                                 id:valclass-canequal-ext
+*#productIterator$extension(*)                          id:valclass-proditer-ext
+*#productElement$extension(*)                           id:valclass-prodelem-ext
+*#productArity$extension(*)                             id:valclass-prodarity-ext
+*#productPrefix$extension(*)                            id:valclass-prodprefix-ext
+*#copy$extension(*)                                     id:valclass-copy-ext
+*#copy$default$*$extension(*)                           id:valclass-copydef-ext
+
+# Function1 trait mixin delegates — single-call forwarders to scala.Function1
+# These arise when a class mixes in Function1. Each is a one-liner forwarding to
+# the trait default. Rarely contain project logic.
+# CAUTION: if your code defines andThen/compose with custom logic in a non-Function1
+# class, rescue those methods with + include rules.
+*#andThen(*)                                            id:fn1-andthen
+*#compose(*)                                            id:fn1-compose
+
+# Default parameter accessors — compiler-generated constant-returning methods
+# The Scala compiler emits a $default$N method for every parameter with a default
+# value. Each method body returns the constant default expression; no logic.
+# This rule supersedes `case-copy-defaults` above; both are safe to keep active.
+*#*$default$*(*)                                        id:gen-defaults
+
+# ─────────────────────────────────────────────────────────────────────────────
+# INCLUDE RULES (rescue methods from broad exclusions above)
+# ─────────────────────────────────────────────────────────────────────────────
+# Prefix a rule with "+" to rescue a method. Include always wins over exclude.
+
 
 # ─────────────────────────────────────────────────────────────────────────────
 # PROJECT RULES

--- a/jmf-rules.txt
+++ b/jmf-rules.txt
@@ -1,5 +1,5 @@
-# jacoco-method-filter — Rules Template (Scala / sbt)
-# [jmf:2.1.0]
+# jacoco-method-filter — Rules Template AbsaOSS/spark-data-standardization
+# [jmf:2.1.1]
 #
 # Syntax reference, pitfalls, examples, and workflows: https://github.com/MoranaApps/jacoco-method-filter/blob/main/docs/rules-reference.md
 #
@@ -123,7 +123,30 @@
 # INCLUDE RULES (rescue methods from broad exclusions above)
 # ─────────────────────────────────────────────────────────────────────────────
 # Prefix a rule with "+" to rescue a method. Include always wins over exclude.
+# GLOBAL RULES  excludes:
+#   *#apply(*)
+#   *#toString()
+#
+# The project has factory methods named `apply` that contain real logic.
+# These rules rescue those project-specific methods so they remain visible  in JaCoCo coverage.
 
++za.co.absa.standardization.numeric.DecimalSymbols$#apply(*)              id:std-include-decimal-symbols-apply
++za.co.absa.standardization.numeric.NumericPattern$#apply(*)              id:std-include-numeric-pattern-apply
+
++za.co.absa.standardization.types.parsers.DecimalParser$#apply(*)         id:std-include-decimal-parser-apply
++za.co.absa.standardization.types.parsers.FractionalParser$#apply(*)      id:std-include-fractional-parser-apply
++za.co.absa.standardization.types.parsers.FractionalParser$#withInfinity(*) id:std-include-fractional-parser-with-infinity
+
++za.co.absa.standardization.time.DateTimePattern$#apply(*)                id:std-include-datetime-pattern-apply
++za.co.absa.standardization.time.DateTimePattern$#asDefault(*)            id:std-include-datetime-pattern-as-default
++za.co.absa.standardization.time.DateTimePattern$#isEpoch(*)              id:std-include-datetime-pattern-is-epoch
+
++za.co.absa.standardization.stages.InfinitySupport$#apply(*)              id:std-include-infinity-support-apply
+
++za.co.absa.standardization.config.BasicErrorCodesConfig$#fromDefault(*)  id:std-include-basic-error-codes-from-default
++za.co.absa.standardization.config.BasicMetadataColumnsConfig$#fromDefault(*) id:std-include-basic-metadata-columns-from-default
+
++za.co.absa.standardization.ErrorMessage$#errorColSchema(*)               id:std-include-error-message-error-col-schema
 
 # ─────────────────────────────────────────────────────────────────────────────
 # PROJECT RULES

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,7 +20,7 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.5")
 
-addSbtPlugin("io.github.moranaapps" % "jacoco-method-filter-sbt" % "2.1.1")
+addSbtPlugin("io.github.moranaapps" % "jacoco-method-filter-sbt" % "2.2.0")
 lazy val ow2Version = "9.5"
 
 def ow2Url(artifactName: String): String = s"https://repo1.maven.org/maven2/org/ow2/asm/$artifactName/$ow2Version/$artifactName-$ow2Version.jar"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -20,8 +20,7 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.5")
 
-// JaCoCo Method Filter sbt Plugin (replaces legacy sbt-jacoco)
-addSbtPlugin("io.github.moranaapps" % "jacoco-method-filter-sbt" % "2.0.1")
+addSbtPlugin("io.github.moranaapps" % "jacoco-method-filter-sbt" % "2.1.1")
 lazy val ow2Version = "9.5"
 
 def ow2Url(artifactName: String): String = s"https://repo1.maven.org/maven2/org/ow2/asm/$artifactName/$ow2Version/$artifactName-$ow2Version.jar"


### PR DESCRIPTION
Release notes:

- Adopts the latest [JaCoCo Method Filter (JMF)](https://github.com/MoranaApps/jacoco-method-filter/blob/master/README.md) plugin  to enable filtering on the method level.
- Updates python version for workflows.

closes https://github.com/AbsaOSS/spark-data-standardization/issues/96