### PR TITLE
Pad numeric date inputs before pattern parsing

### DIFF
--- a/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
@@ -579,16 +579,16 @@ object TypeParser {
         s"$inputFullPathName is specified as timestamp or date, but original type is ${originType.typeName}. Trying to interpret as string."
       )
       val stringColumn = nonStringColumn.cast(StringType)
-      val stringColumnWithPadding = if (isNumericType(originType)) {
-        lpad(stringColumn, pattern.length, "0")
+      val stringColumnWithPadding = if (shouldPadNumericDateTimeString(originType)) {
+        lpad(stringColumn, pattern.pattern.length, "0")
       } else {
         stringColumn
       }
       castStringColumn(stringColumnWithPadding)
     }
 
-    private def isNumericType(dataType: DataType): Boolean = dataType match {
-      case ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType | _: DecimalType => true
+    private def shouldPadNumericDateTimeString(dataType: DataType): Boolean = dataType match {
+      case ByteType | ShortType | IntegerType | LongType => !pattern.isCentury
       case _ => false
     }
 

--- a/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
@@ -578,7 +578,18 @@ object TypeParser {
       logger.warn(
         s"$inputFullPathName is specified as timestamp or date, but original type is ${originType.typeName}. Trying to interpret as string."
       )
-      castStringColumn(nonStringColumn.cast(StringType))
+      val stringColumn = nonStringColumn.cast(StringType)
+      val stringColumnWithPadding = if (isNumericType(originType)) {
+        lpad(stringColumn, pattern.length, "0")
+      } else {
+        stringColumn
+      }
+      castStringColumn(stringColumnWithPadding)
+    }
+
+    private def isNumericType(dataType: DataType): Boolean = dataType match {
+      case ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType | _: DecimalType => true
+      case _ => false
     }
 
     protected def castEpoch(): Column = {

--- a/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
@@ -580,7 +580,8 @@ object TypeParser {
       )
       val stringColumn = nonStringColumn.cast(StringType)
       val stringColumnWithPadding = if (shouldPadNumericDateTimeString(originType)) {
-        when(length(stringColumn) < pattern.pattern.length, lpad(stringColumn, pattern.pattern.length, "0"))
+        when(length(stringColumn) > pattern.pattern.length, lit(null).cast(StringType))
+          .when(length(stringColumn) < pattern.pattern.length, lpad(stringColumn, pattern.pattern.length, "0"))
           .otherwise(stringColumn)
       } else {
         stringColumn

--- a/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
@@ -580,7 +580,8 @@ object TypeParser {
       )
       val stringColumn = nonStringColumn.cast(StringType)
       val stringColumnWithPadding = if (shouldPadNumericDateTimeString(originType)) {
-        lpad(stringColumn, pattern.pattern.length, "0")
+        when(length(stringColumn) < pattern.pattern.length, lpad(stringColumn, pattern.pattern.length, "0"))
+          .otherwise(stringColumn)
       } else {
         stringColumn
       }

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
@@ -260,7 +260,8 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
     val seq: Seq[Int] = Seq(
       2092024,
       1012024,
-      31122024
+      31122024,
+      101202024
     )
     val desiredSchema = StructType(Seq(
       StructField(fieldName, DateType, nullable = false,
@@ -269,7 +270,8 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
     val exp: Seq[DateRow] = Seq(
       DateRow(Date.valueOf("2024-09-02")),
       DateRow(Date.valueOf("2024-01-01")),
-      DateRow(Date.valueOf("2024-12-31"))
+      DateRow(Date.valueOf("2024-12-31")),
+      DateRow(Date.valueOf("1970-01-01"), Seq(StandardizationErrorMessage.stdCastErr(fieldName, "101202024", "integer", "date", Some("ddMMyyyy"))))
     )
 
     val src = seq.toDF(fieldName)

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_DateSuite.scala
@@ -256,6 +256,30 @@ class StandardizationInterpreter_DateSuite extends AnyFunSuite with SparkTestBas
     assertResult(exp)(std.as[DateRow].collect().toList)
   }
 
+  test("date pattern from numeric value with leading zero") {
+    val seq: Seq[Int] = Seq(
+      2092024,
+      1012024,
+      31122024
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, DateType, nullable = false,
+        new MetadataBuilder().putString(MetadataKeys.Pattern, "ddMMyyyy").build)
+    ))
+    val exp: Seq[DateRow] = Seq(
+      DateRow(Date.valueOf("2024-09-02")),
+      DateRow(Date.valueOf("2024-01-01")),
+      DateRow(Date.valueOf("2024-12-31"))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[DateRow].collect().toList)
+  }
+
   test("date + time pattern and named time zone") {
     val seq  = Seq(
       "01-00-00 01.01.1970 CET",

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreter_TimestampSuite.scala
@@ -265,6 +265,30 @@ class StandardizationInterpreter_TimestampSuite extends AnyFunSuite with SparkTe
     assertResult(exp)(std.as[TimestampRow].collect().toList)
   }
 
+  test("pattern up to seconds precision from numeric value with leading zero") {
+    val seq: Seq[Long] = Seq(
+      2092024010203L,
+      1012024000000L,
+      31122024235959L
+    )
+    val desiredSchema = StructType(Seq(
+      StructField(fieldName, TimestampType, nullable = false,
+        new MetadataBuilder().putString("pattern", "ddMMyyyyHHmmss").build)
+    ))
+    val exp = Seq(
+      TimestampRow(Timestamp.valueOf("2024-09-02 01:02:03")),
+      TimestampRow(Timestamp.valueOf("2024-01-01 00:00:00")),
+      TimestampRow(Timestamp.valueOf("2024-12-31 23:59:59"))
+    )
+
+    val src = seq.toDF(fieldName)
+
+    val std = Standardization.standardize(src, desiredSchema).cacheIfNotCachedYet()
+    logDataFrameContent(std)
+
+    assertResult(exp)(std.as[TimestampRow].collect().toList)
+  }
+
   test("pattern up to seconds precision with default time zone") {
     val seq  = Seq(
       "31.12.1969 19-00-00",

--- a/src/test/scala/za/co/absa/standardization/interpreter/stages/TypeParser_FromLongTypeSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/stages/TypeParser_FromLongTypeSuite.scala
@@ -43,7 +43,10 @@ class TypeParser_FromLongTypeSuite extends TypeParserSuiteTemplate {
       (infMinusValue, infMinusSymbol, infPlusValue, infPlusSymbol)
     }
     val srcType = srcStructField.dataType.sql
-    def paddedStringColumn: String = s"lpad(CAST(`%s` AS STRING), ${pattern.length}, '0')"
+    val castStringColumn = "CAST(`%s` AS STRING)"
+    def paddedStringColumn: String =
+      s"CASE WHEN (length($castStringColumn) < ${pattern.length}) THEN " +
+        s"lpad($castStringColumn, ${pattern.length}, '0') ELSE $castStringColumn END"
 
     val isEpoch = DateTimePattern.isEpoch(pattern)
     (target.dataType, isEpoch, timezone) match {

--- a/src/test/scala/za/co/absa/standardization/interpreter/stages/TypeParser_FromLongTypeSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/stages/TypeParser_FromLongTypeSuite.scala
@@ -43,15 +43,16 @@ class TypeParser_FromLongTypeSuite extends TypeParserSuiteTemplate {
       (infMinusValue, infMinusSymbol, infPlusValue, infPlusSymbol)
     }
     val srcType = srcStructField.dataType.sql
+    def paddedStringColumn: String = s"lpad(CAST(`%s` AS STRING), ${pattern.length}, '0')"
 
     val isEpoch = DateTimePattern.isEpoch(pattern)
     (target.dataType, isEpoch, timezone) match {
       case (DateType, true, _)                      => s"to_date(CAST((CAST(`%s` AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}L) AS TIMESTAMP))"
       case (TimestampType, true, _)                 => s"CAST((CAST(%s AS DECIMAL(30,9)) / ${DateTimePattern.epochFactor(pattern)}) AS TIMESTAMP)"
-      case (DateType, _, Some(tz))                  => s"to_date(to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), '$tz'))"
-      case (TimestampType, _, Some(tz))             => s"to_utc_timestamp(to_timestamp(CAST(`%s` AS STRING), '$pattern'), $tz)"
-      case (TimestampType, _, _)                    => s"to_timestamp(CAST(`%s` AS STRING), '$pattern')"
-      case (DateType, _, _)                         => s"to_date(CAST(`%s` AS STRING), '$pattern')"
+      case (DateType, _, Some(tz))                  => s"to_date(to_utc_timestamp(to_timestamp($paddedStringColumn, '$pattern'), '$tz'))"
+      case (TimestampType, _, Some(tz))             => s"to_utc_timestamp(to_timestamp($paddedStringColumn, '$pattern'), $tz)"
+      case (TimestampType, _, _)                    => s"to_timestamp($paddedStringColumn, '$pattern')"
+      case (DateType, _, _)                         => s"to_date($paddedStringColumn, '$pattern')"
       case (ByteType | ShortType | IntegerType | LongType | FloatType | DoubleType | _: DecimalType, _, _) if (infMinusValue.isDefined && infMinusSymbol.isDefined && infPlusValue.isDefined && infPlusSymbol.isDefined) =>
         s"CAST(CASE WHEN (CASE WHEN (%s = ${infMinusSymbol.get}) THEN CAST(${infMinusValue.get} AS $srcType) " +
           s"ELSE %s END = ${infPlusSymbol.get}) THEN CAST(${infPlusValue.get} AS $srcType) ELSE CASE WHEN " +

--- a/src/test/scala/za/co/absa/standardization/interpreter/stages/TypeParser_FromLongTypeSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/stages/TypeParser_FromLongTypeSuite.scala
@@ -45,8 +45,9 @@ class TypeParser_FromLongTypeSuite extends TypeParserSuiteTemplate {
     val srcType = srcStructField.dataType.sql
     val castStringColumn = "CAST(`%s` AS STRING)"
     def paddedStringColumn: String =
-      s"CASE WHEN (length($castStringColumn) < ${pattern.length}) THEN " +
-        s"lpad($castStringColumn, ${pattern.length}, '0') ELSE $castStringColumn END"
+      s"CASE WHEN (length($castStringColumn) > ${pattern.length}) THEN CAST(NULL AS STRING) " +
+        s"WHEN (length($castStringColumn) < ${pattern.length}) THEN lpad($castStringColumn, ${pattern.length}, '0') " +
+        s"ELSE $castStringColumn END"
 
     val isEpoch = DateTimePattern.isEpoch(pattern)
     (target.dataType, isEpoch, timezone) match {


### PR DESCRIPTION
## Summary
- Left-pad numeric date/timestamp inputs to the configured pattern width before parsing with Spark date/time functions.
- Preserve existing behavior for string/date/timestamp inputs and epoch patterns.
- Add regression coverage for `2092024` with `ddMMyyyy` and numeric timestamps missing a leading zero.

Fixes #107.

## Testing
- `git diff --check`
- Not run: Scala/Spark test suite locally because this environment does not have `java` or `sbt` available on `PATH`.