### PR TITLE
Preserve nested field metadata during standardization

### DIFF
--- a/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
@@ -216,7 +216,7 @@ object TypeParser {
         .otherwise(
           typedLit(flatten(transform(column, lambdaErrCols, lambdaVariableName)))
         )
-      val stdCols = transform(column, lambdaStdCols, lambdaVariableName).cast(fieldType)
+      val stdCols = transform(column, lambdaStdCols, lambdaVariableName)
       logger.info(s"Finished standardization plan for Array $inputFullPathName")
       ParseOutput(stdCols as (fieldOutputName, metadata), finalErrs)
     }
@@ -240,7 +240,9 @@ object TypeParser {
         val origSubFieldType = origSubField.map(_.dataType).getOrElse(NullType)
         val subColumn = origSubField.map(x => column(x.name)).getOrElse(nullColumn)
         TypeParser(f, inputFullPathName, subColumn, origSubFieldType, failOnInputNotPerSchema).standardize(stdConfig)}
-      val cols = out.map(_.stdCol)
+      val cols = out.zip(fieldType.fields).map { case (parseOutput, targetField) =>
+        parseOutput.stdCol as (targetField.name, targetField.metadata)
+      }
       val errs = out.map(_.errors)
       // condition for nullable error of the struct itself
       val nullErrCond = column.isNull and lit(!field.nullable)
@@ -256,7 +258,7 @@ object TypeParser {
           )
       )
       // rebuild the struct
-      val outputColumn = when(column.isNull, lit(null)).otherwise(struct(cols: _*)).cast(fieldType) as (fieldOutputName, metadata)
+      val outputColumn = when(column.isNull, lit(null)).otherwise(struct(cols: _*)) as (fieldOutputName, metadata)
 
       ParseOutput(outputColumn, errs1)
     }

--- a/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
+++ b/src/main/scala/za/co/absa/standardization/stages/TypeParser.scala
@@ -216,7 +216,7 @@ object TypeParser {
         .otherwise(
           typedLit(flatten(transform(column, lambdaErrCols, lambdaVariableName)))
         )
-      val stdCols = transform(column, lambdaStdCols, lambdaVariableName)
+      val stdCols = transform(column, lambdaStdCols, lambdaVariableName).cast(fieldType)
       logger.info(s"Finished standardization plan for Array $inputFullPathName")
       ParseOutput(stdCols as (fieldOutputName, metadata), finalErrs)
     }
@@ -256,7 +256,7 @@ object TypeParser {
           )
       )
       // rebuild the struct
-      val outputColumn = when(column.isNull, lit(null)).otherwise(struct(cols: _*)) as (fieldOutputName, metadata)
+      val outputColumn = when(column.isNull, lit(null)).otherwise(struct(cols: _*)).cast(fieldType) as (fieldOutputName, metadata)
 
       ParseOutput(outputColumn, errs1)
     }

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreterSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreterSuite.scala
@@ -263,30 +263,69 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
   test("Test standardization preserves metadata of nested fields") {
     val rootMetadata = new MetadataBuilder().putLong("maxLength", 8).build()
     val nestedMetadata = new MetadataBuilder().putLong("maxLength", 5).build()
+    val deepMetadata = new MetadataBuilder().putLong("maxLength", 4).build()
 
     val sourceSchema = StructType(Seq(
       StructField("STRING_FIELD", StringType, nullable = true),
       StructField("NESTED_STRUCT", StructType(Seq(
-        StructField("NESTED_STRING", StringType, nullable = true)
+        StructField("NESTED_STRING", StringType, nullable = true),
+        StructField("DEEP_STRUCT", StructType(Seq(
+          StructField("DEEP_STRING", StringType, nullable = true)
+        )), nullable = true)
       )), nullable = true)
     ))
 
     val desiredSchema = StructType(Seq(
       StructField("STRING_FIELD", StringType, nullable = true, rootMetadata),
       StructField("NESTED_STRUCT", StructType(Seq(
-        StructField("NESTED_STRING", StringType, nullable = true, nestedMetadata)
+        StructField("NESTED_STRING", StringType, nullable = true, nestedMetadata),
+        StructField("DEEP_STRUCT", StructType(Seq(
+          StructField("DEEP_STRING", StringType, nullable = true, deepMetadata)
+        )), nullable = true)
       )), nullable = true)
     ))
 
     val sourceDF = spark.createDataFrame(
-      spark.sparkContext.parallelize(Seq(Row("metadata", Row("inner")))),
+      spark.sparkContext.parallelize(Seq(Row("metadata", Row("inner", Row("deep"))))),
       sourceSchema
     )
 
     val standardizedDF = Standardization.standardize(sourceDF, desiredSchema, stdConfig)
+    val nestedStructType = standardizedDF.schema("NESTED_STRUCT").dataType.asInstanceOf[StructType]
+    val deepStructType = nestedStructType("DEEP_STRUCT").dataType.asInstanceOf[StructType]
 
     assert(standardizedDF.schema("STRING_FIELD").metadata === rootMetadata)
-    assert(standardizedDF.schema("NESTED_STRUCT").dataType.asInstanceOf[StructType]("NESTED_STRING").metadata === nestedMetadata)
+    assert(nestedStructType("NESTED_STRING").metadata === nestedMetadata)
+    assert(deepStructType("DEEP_STRING").metadata === deepMetadata)
+  }
+
+  test("Test standardization preserves metadata of fields inside array elements") {
+    val arrayElementMetadata = new MetadataBuilder().putLong("maxLength", 6).build()
+
+    val sourceSchema = StructType(Seq(
+      StructField("ARRAY_STRUCT", ArrayType(StructType(Seq(
+        StructField("ARRAY_STRING", StringType, nullable = true)
+      ))), nullable = true)
+    ))
+
+    val desiredSchema = StructType(Seq(
+      StructField("ARRAY_STRUCT", ArrayType(StructType(Seq(
+        StructField("ARRAY_STRING", StringType, nullable = true, arrayElementMetadata)
+      ))), nullable = true)
+    ))
+
+    val sourceDF = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row(Seq(Row("inside"))))),
+      sourceSchema
+    )
+
+    val standardizedDF = Standardization.standardize(sourceDF, desiredSchema, stdConfig)
+    val arrayElementType = standardizedDF.schema("ARRAY_STRUCT").dataType
+      .asInstanceOf[ArrayType]
+      .elementType
+      .asInstanceOf[StructType]
+
+    assert(arrayElementType("ARRAY_STRING").metadata === arrayElementMetadata)
   }
 
   test ("Test standardization of Date and Timestamp fields with default value and pattern") {

--- a/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreterSuite.scala
+++ b/src/test/scala/za/co/absa/standardization/interpreter/StandardizationInterpreterSuite.scala
@@ -16,6 +16,7 @@
 
 package za.co.absa.standardization.interpreter
 
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.scalatest.funsuite.AnyFunSuite
@@ -257,6 +258,35 @@ class StandardizationInterpreterSuite extends AnyFunSuite with SparkTestBase wit
     assert(detailsValues(0).getStruct(0) != null, "Record 1 should have a non-null details struct")
     assert(detailsValues(1).isNullAt(0), "Record 2 should have a null details struct in the output")
     assert(detailsValues(2).isNullAt(0), "Record 3 should have a null details struct in the output")
+  }
+
+  test("Test standardization preserves metadata of nested fields") {
+    val rootMetadata = new MetadataBuilder().putLong("maxLength", 8).build()
+    val nestedMetadata = new MetadataBuilder().putLong("maxLength", 5).build()
+
+    val sourceSchema = StructType(Seq(
+      StructField("STRING_FIELD", StringType, nullable = true),
+      StructField("NESTED_STRUCT", StructType(Seq(
+        StructField("NESTED_STRING", StringType, nullable = true)
+      )), nullable = true)
+    ))
+
+    val desiredSchema = StructType(Seq(
+      StructField("STRING_FIELD", StringType, nullable = true, rootMetadata),
+      StructField("NESTED_STRUCT", StructType(Seq(
+        StructField("NESTED_STRING", StringType, nullable = true, nestedMetadata)
+      )), nullable = true)
+    ))
+
+    val sourceDF = spark.createDataFrame(
+      spark.sparkContext.parallelize(Seq(Row("metadata", Row("inner")))),
+      sourceSchema
+    )
+
+    val standardizedDF = Standardization.standardize(sourceDF, desiredSchema, stdConfig)
+
+    assert(standardizedDF.schema("STRING_FIELD").metadata === rootMetadata)
+    assert(standardizedDF.schema("NESTED_STRUCT").dataType.asInstanceOf[StructType]("NESTED_STRING").metadata === nestedMetadata)
   }
 
   test ("Test standardization of Date and Timestamp fields with default value and pattern") {


### PR DESCRIPTION
## Summary
- Preserve nested struct field metadata by aliasing rebuilt struct children with metadata from the target schema.
- Remove whole array/struct casts that Spark 3+ rejects even when source and target structures are identical.
- Extend regression coverage for deeper nested struct metadata and fields inside `ArrayType(StructType(...))` elements.

## Release Notes
- Fixed nested field metadata preservation during standardization.

## Verification
- `git diff --check`
- GitHub Actions: Scala 2.12.18, Scala 2.13.11, `test (2.12.20, 2.12, 80, 80, 60)`, and `license-test` passed for commit `6a5dffe`.
- Not run locally: Scala/Spark test suite because this environment does not have `java`, `mvn`, or `sbt` available on `PATH`.

Fixes #56